### PR TITLE
0.25

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,15 @@
+0.25  2025-04-07
+    - Added support for aggregation functions:
+        * add   - sum of numeric arrays
+        * min   - minimum value of numeric arrays
+        * max   - maximum value of numeric arrays
+        * avg   - average of numeric arrays
+    - Improved CLI argument parsing:
+        * Queries no longer require a leading dot (e.g. 'map(...)' now works)
+        * File arguments are more accurately distinguished from query strings
+        * Interactive mode works even without a query when only a JSON file is provided
+    - Confirmed compatibility of map(), select(), and arithmetic expressions across CLI and interactive modes
+    - All previous features and test cases remain working and fully compatible
 0.24  2025-04-06
     - Added support for numeric expressions inside select(), e.g.:
         select(.id + 5 > 20)

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -113,6 +113,7 @@ my $filename;
 
 while (@ARGV) {
     my $arg = shift @ARGV;
+
     if ($arg eq '--raw-output' || $arg eq '-r') {
         $raw_output = 1;
     }
@@ -150,24 +151,16 @@ USAGE
         print "jq-lite version $JQ::Lite::VERSION\n";
         exit 0;
     }
-    elsif (!defined $query && $arg =~ /^\./) {
-        $query = $arg;
+    # First check if this argument is a file
+    elsif (!defined $filename && -f $arg) {
+        $filename = $arg;
     }
-    elsif (!defined $query && $arg =~ /^[a-zA-Z0-9_\.\(\)\[\]\|\s!=><\"\'-]+$/) {
-        # allow function-style queries like map(...)
-        $query = $arg;
-    }
-    elsif (!defined $query && !-f $arg) {
-        $query = $arg;
-    }
+    # If not a file and query is not yet set, treat it as the query string
     elsif (!defined $query) {
-        if (-f $arg) {
-            $filename = $arg;
-        } else {
-            $query = $arg;
-        }
+        $query = $arg;
     }
-    elsif (!defined $filename) {
+    # Secondary filename fallback
+    elsif (!defined $filename && -f $arg) {
         $filename = $arg;
     }
     else {

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -3,8 +3,9 @@ package JQ::Lite;
 use strict;
 use warnings;
 use JSON::PP;
+use List::Util qw(sum min max);
 
-our $VERSION = '0.24';
+our $VERSION = '0.25';
 
 sub new {
     my ($class, %opts) = @_;
@@ -130,6 +131,42 @@ sub run_query {
                 ref $_ eq 'ARRAY'
                     ? [ grep { defined($_) } map { $self->run_query(encode_json($_), $filter) } @$_ ]
                     : $_
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for add
+        if ($part eq 'add') {
+            @next_results = map {
+                ref $_ eq 'ARRAY' ? sum(map { 0 + $_ } @$_) : $_
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for min
+        if ($part eq 'min') {
+            @next_results = map {
+                ref $_ eq 'ARRAY' ? min(map { 0 + $_ } @$_) : $_
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for max
+        if ($part eq 'max') {
+            @next_results = map {
+                ref $_ eq 'ARRAY' ? max(map { 0 + $_ } @$_) : $_
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for avg
+        if ($part eq 'avg') {
+            @next_results = map {
+                ref $_ eq 'ARRAY' && @$_ ? sum(map { 0 + $_ } @$_) / scalar(@$_) : 0
             } @results;
             @results = @next_results;
             next;
@@ -388,7 +425,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 0.24
+Version 0.25
 
 =head1 SYNOPSIS
 

--- a/t/aggregate.t
+++ b/t/aggregate.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q([
+  { "value": 10 },
+  { "value": 30 },
+  { "value": 20 }
+]);
+
+my $jq = JQ::Lite->new;
+
+my ($add) = $jq->run_query($json, 'map(.value) | add');
+is($add, 60, 'add = 60');
+
+my ($min) = $jq->run_query($json, 'map(.value) | min');
+is($min, 10, 'min = 10');
+
+my ($max) = $jq->run_query($json, 'map(.value) | max');
+is($max, 30, 'max = 30');
+
+my ($avg) = $jq->run_query($json, 'map(.value) | avg');
+is($avg, 20, 'avg = 20');
+
+done_testing;


### PR DESCRIPTION
0.25  2025-04-07
    - Added support for aggregation functions:
        * add   - sum of numeric arrays
        * min   - minimum value of numeric arrays
        * max   - maximum value of numeric arrays
        * avg   - average of numeric arrays
    - Improved CLI argument parsing:
        * Queries no longer require a leading dot (e.g. 'map(...)' now works)
        * File arguments are more accurately distinguished from query strings
        * Interactive mode works even without a query when only a JSON file is provided
    - Confirmed compatibility of map(), select(), and arithmetic expressions across CLI and interactive modes
    - All previous features and test cases remain working and fully compatible