### PR TITLE
0.27

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.27  2025-04-12
+    - Added support for pipe-style queries using .[] (e.g. .[] | select(...) | .name)
+    - Introduced 'flatten' as internal command for .[] handling
+    - Improved run_query parsing to better support chained queries with select()
+    - Added test: t/pipe_select_name.t
+
 0.26  2025-04-06
     - Improved interactive mode: input prompt is now always displayed at the bottom of the screen
       to avoid being overwritten by JSON output. This improves readability and usability when working

--- a/MANIFEST
+++ b/MANIFEST
@@ -16,3 +16,4 @@ t/reverse.t
 t/sort_unique.t
 t/map.t
 t/arithmetic.t
+t/pipe_select_name.t

--- a/t/pipe_select_name.t
+++ b/t/pipe_select_name.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my $json = <<'JSON';
+[
+  { "name": "Alice", "age": 30 },
+  { "name": "Bob",   "age": 20 },
+  { "name": "Carol", "age": 25 }
+]
+JSON
+
+my @res = $jq->run_query($json, '.[] | select(.age > 21) | .name');
+
+is_deeply(\@res, ["Alice", "Carol"], 'Pipe with .[] | select | .name works correctly');
+
+done_testing;


### PR DESCRIPTION
0.27  2025-04-12
    - Added support for pipe-style queries using .[] (e.g. .[] | select(...) | .name)
    - Introduced 'flatten' as internal command for .[] handling
    - Improved run_query parsing to better support chained queries with select()
    - Added test: t/pipe_select_name.t