### PR TITLE
0.29

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+0.29  2025-04-12
+    - Added count function to return the number of items in the result set
+    - Example: .users | count  → returns array length
+              .users[] | select(...) | count → counts matching items
+    - Adjusted count logic to treat both arrays and flat result lists properly
+    - Added test: t/count.t
+
 0.28  2025-04-12
     - Added group_by(...) function to group arrays by a field
     - Example: .users | group_by(department)

--- a/MANIFEST
+++ b/MANIFEST
@@ -18,3 +18,5 @@ t/map.t
 t/arithmetic.t
 t/pipe_select_name.t
 t/group_by.t
+t/count.t
+t/count.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -19,4 +19,3 @@ t/arithmetic.t
 t/pipe_select_name.t
 t/group_by.t
 t/count.t
-t/count.t

--- a/t/count.t
+++ b/t/count.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my $json = <<'JSON';
+{
+  "users": [
+    { "name": "Alice", "age": 30 },
+    { "name": "Bob",   "age": 22 },
+    { "name": "Carol", "age": 19 }
+  ]
+}
+JSON
+
+my @res1 = $jq->run_query($json, '.users | count');
+is_deeply(\@res1, [3], 'count users');
+
+my @res2 = $jq->run_query($json, '.users[] | select(.age > 25) | count');
+is_deeply(\@res2, [1], 'count users over 25');
+
+done_testing;


### PR DESCRIPTION
0.29  2025-04-12
    - Added count function to return the number of items in the result set
    - Example: .users | count  → returns array length
              .users[] | select(...) | count → counts matching items
    - Adjusted count logic to treat both arrays and flat result lists properly
    - Added test: t/count.t