### PR TITLE
Fix unexpected warnings from sort_by comparator

### DIFF
--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -241,9 +241,7 @@ sub run_query {
                     my @sorted = sort {
                         my $a_val = (_traverse($a, $key_path))[0] // '';
                         my $b_val = (_traverse($b, $key_path))[0] // '';
-        
-                        warn "[DEBUG] a=$a_val, b=$b_val => cmp=" . $cmp->($a_val, $b_val) . "\n";
-        
+
                         $cmp->($a_val, $b_val);
                     } @$item;
         

--- a/t/sort_by.t
+++ b/t/sort_by.t
@@ -16,12 +16,23 @@ JSON
 my $jq = JQ::Lite->new;
 
 # Test sort_by(.age)
-my @result = $jq->run_query($json, '.users | sort_by(.age) | map(.name)');
+my @warnings;
+my @result;
+{
+    local $SIG{__WARN__} = sub { push @warnings, @_ };
+    @result = $jq->run_query($json, '.users | sort_by(.age) | map(.name)');
+}
 
 is_deeply(
     \@result,
     [['Bob', 'Carol', 'Alice']],
     'sort_by(.age) returns users sorted by age'
+);
+
+is_deeply(
+    \@warnings,
+    [],
+    'sort_by does not emit unexpected warnings'
 );
 
 done_testing();


### PR DESCRIPTION
## Summary
- remove stray debug logging from the sort_by comparator
- extend the sort_by test to assert that the helper emits no warnings

## Testing
- prove -l

------
https://chatgpt.com/codex/tasks/task_e_68e0789d1b688330a4ef443899e111ce