### PR TITLE
Prepare 0.44 release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-0.44  2025-04-29
+0.44  2025-10-04
     - Prepare release for version 0.44.
     - Added standalone LICENSE file and included it in MANIFEST for kwalitee compliance.
 
@@ -206,3 +206,4 @@
     - Removed use of eval in _evaluate_condition for better performance and stability.
     - Refactored _traverse for readability and maintainability.
     - Added support for multi-level array traversal (e.g., .users[].friends[].name).
+

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+0.44  2025-04-29
+    - Prepare release for version 0.44.
+    - Added standalone LICENSE file and included it in MANIFEST for kwalitee compliance.
+
 0.42  2025-04-28
     - Added new function: default(value)
       * default() returns the specified value if the current value is undef or null.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+This software is copyright (c) 2024 Kawamura Shingo.
+
+This library is free software; you can redistribute it and/or modify it
+under the same terms as Perl 5 itself.  That means either:
+
+    * the "Artistic License" (as shipped with the Perl 5 source code), or
+    * the "GNU General Public License" version 1 (or, at your option, any
+      later version).
+
+Copies of these licenses should have been supplied with your Perl 5
+distribution.  If not, they are available online at:
+
+    https://perldoc.perl.org/Artistic.html
+    https://www.gnu.org/licenses/old-licenses/gpl-1.0.html
+
+You may distribute this software under either of those licenses.

--- a/MANIFEST
+++ b/MANIFEST
@@ -27,3 +27,4 @@ t/reverse.t
 t/sort_by.t
 t/sort_unique.t
 t/values.t
+LICENSE

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -5,7 +5,7 @@ use warnings;
 use JSON::PP;
 use List::Util qw(sum min max);
 
-our $VERSION = '0.43';
+our $VERSION = '0.44';
 
 sub new {
     my ($class, %opts) = @_;


### PR DESCRIPTION
## Summary
- prepare the CPAN 0.44 release by bumping the module version and updating the changelog to describe the kwalitee-related licensing changes

## Testing
- prove -l

------
https://chatgpt.com/codex/tasks/task_e_68e07defe04883309fd45755702392d1