### PR TITLE
Improve median aggregation robustness

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.45  2025-10-04
+    - Added median() aggregation helper with numeric filtering using looks_like_number().
+    - Documented the median function and added dedicated tests covering mixed numeric formats.
+    - Updated MANIFEST and module documentation for the new release.
+
 0.44  2025-10-04
     - Prepare release for version 0.44.
     - Added standalone LICENSE file and included it in MANIFEST for kwalitee compliance.

--- a/MANIFEST
+++ b/MANIFEST
@@ -19,6 +19,7 @@ t/has.t
 t/join.t
 t/limit.t
 t/map.t
+t/median.t
 t/match.t
 t/match_i.t
 t/pipe_select_name.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `count`, `join`, `empty()` 
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `count`, `join`, `empty()`, `median`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -55,7 +55,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `limit(n)`     | Limit array to first `n` elements                    |
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
-| `add`, `min`, `max`, `avg` | Numeric aggregation functions            |
+| `add`, `min`, `max`, `avg`, `median` | Numeric aggregation functions            |
 | `group_by(key)`| Group array items by field                           |
 | `count`        | Count total number of matching items                 |
 | `join(sep)`    | Join array elements with custom separator (v0.31+)   |

--- a/t/median.t
+++ b/t/median.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json_objects = q([
+  { "value": 10 },
+  { "value": 30 },
+  { "value": 20 }
+]);
+
+my $json_even = q([1, 3, 5, 7]);
+my $json_mixed = q(["foo", 2, 4, "bar"]);
+my $json_no_numeric = q(["foo", "bar"]);
+my $json_scientific = q([1e2, "200", 50]);
+
+my $jq = JQ::Lite->new;
+
+my ($median_objects) = $jq->run_query($json_objects, 'map(.value) | median');
+is($median_objects, 20, 'median over mapped values');
+
+my ($median_even) = $jq->run_query($json_even, 'median');
+is($median_even, 4, 'median averages the middle pair for even-length arrays');
+
+my ($median_mixed) = $jq->run_query($json_mixed, 'median');
+is($median_mixed, 3, 'median uses only numeric values');
+
+my ($median_no_numeric) = $jq->run_query($json_no_numeric, 'median');
+ok(!defined $median_no_numeric, 'median returns undef when no numeric values are present');
+
+my ($median_scientific) = $jq->run_query($json_scientific, 'median');
+is($median_scientific, 100, 'median handles scientific notation and numeric strings');
+
+done_testing;


### PR DESCRIPTION
## Summary
- use Scalar::Util::looks_like_number for the median aggregator and keep non-array inputs unchanged
- document the 0.45 release in Changes, bump the module POD version, and include the new test in MANIFEST
- extend median.t to cover scientific-notation inputs alongside existing numeric cases

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e08003c65483309b703d04e6cd7c59