### PR TITLE
Prepare v0.48 release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+0.48  2025-10-05
+    - Updated the --help-functions listing to cover every built-in helper.
+    - Bumped version number for the 0.48 release.
+
 0.47  2025-10-04
     - Added upper()/lower() helpers for case conversion of scalars and arrays.
     - Documented the new functions and listed them in --help-functions output.

--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-0.48  2025-10-05
+0.48  2025-10-04
     - Updated the --help-functions listing to cover every built-in helper.
     - Bumped version number for the 0.48 release.
 
@@ -224,4 +224,5 @@
     - Removed use of eval in _evaluate_condition for better performance and stability.
     - Refactored _traverse for readability and maintainability.
     - Added support for multi-level array traversal (e.g., .users[].friends[].name).
+
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `compact()`    | Remove undef/null values from arrays (v0.39)         |
 | `upper()`      | Convert scalars (and array elements) to uppercase (v0.47) |
 | `lower()`      | Convert scalars (and array elements) to lowercase (v0.47) |
+| `path()`       | Return keys (for objects) or indices (for arrays) (v0.40) |
+| `is_empty`     | True when the value is an empty array or object (v0.41)   |
+| `default(value)` | Substitute a fallback value when the result is undef/null (v0.42) |
 
 ---
 

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -327,22 +327,34 @@ Supported Functions:
   values           - Extract values from a hash (v0.34)
   sort             - Sort array items
   sort_by(KEY)     - Sort array of objects by key
+  pluck(KEY)       - Collect a key's value from each object in an array
   unique           - Remove duplicate values
   reverse          - Reverse an array
   first / last     - Get first / last element of an array
   limit(N)         - Limit array to first N elements
   count            - Count total number of matching items
   map(EXPR)        - Map/filter array items with a subquery
+  add              - Sum all numeric values in an array
+  min / max        - Return minimum / maximum numeric value in an array
+  avg              - Return the average of numeric values in an array
+  median           - Return the median of numeric values in an array
+  nth(N)           - Get the Nth element of an array (zero-based index)
   group_by(KEY)    - Group array items by field
+  group_count(KEY) - Count grouped items by field
   join(SEPARATOR)  - Join array elements with a string
   has              - Check if object has a given key
   contains         - Check if array or string contains a value
   match("pattern") - Match string using regex
   flatten          - Explicitly flatten arrays (same as .[])
+  del(KEY)         - Remove a key from objects in the result
+  compact          - Remove undefined values from arrays
+  path             - Return available keys for objects or indexes for arrays
+  is_empty         - Check if an array or object is empty
   upper()          - Convert scalars and array elements to uppercase
   lower()          - Convert scalars and array elements to lowercase
   empty            - Discard all output (for side-effect use)
   type()           - Return the type of value ("string", "number", "boolean", "array", "object", "null")
+  default(VALUE)   - Substitute VALUE when result is undefined
 
 EOF
 }

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -6,7 +6,7 @@ use JSON::PP;
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 
-our $VERSION = '0.47';
+our $VERSION = '0.48';
 
 sub new {
     my ($class, %opts) = @_;


### PR DESCRIPTION
## Summary
- bump the module version constant to 0.48 for the next release
- add a 0.48 entry to the Changes file covering the refreshed help output
- extend the README function table with the helpers introduced in recent releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0874bc4308330932a2552f77e25d1