### PR TITLE
Add abs() helper for absolute value transformations

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.49  2025-10-05
+    - Added abs() helper to convert numbers (and arrays of numbers) to their
+      absolute values.
+    - Documented the new function and listed it in --help-functions output.
+    - Added regression tests covering scalar and array usage.
+
 0.48  2025-10-04
     - Updated the --help-functions listing to cover every built-in helper.
     - Bumped version number for the 0.48 release.

--- a/MANIFEST
+++ b/MANIFEST
@@ -5,6 +5,7 @@ Makefile.PL
 MANIFEST			This list of files
 MANIFEST.SKIP
 README.md
+t/abs.t
 t/aggregate.t
 t/arithmetic.t
 t/basic.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `empty()`, `median`, `upper()`, `lower()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `empty()`, `median`, `upper()`, `lower()`, `abs()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -56,6 +56,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `add`, `min`, `max`, `avg`, `median` | Numeric aggregation functions            |
+| `abs`         | Convert numeric values to their absolute value (v0.49) |
 | `group_by(key)`| Group array items by field                           |
 | `group_count(key)` | Count how many items fall under each key (v0.46)   |
 | `count`        | Count total number of matching items                 |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -338,6 +338,7 @@ Supported Functions:
   min / max        - Return minimum / maximum numeric value in an array
   avg              - Return the average of numeric values in an array
   median           - Return the median of numeric values in an array
+  abs              - Convert numbers (and array elements) to their absolute value
   nth(N)           - Get the Nth element of an array (zero-based index)
   group_by(KEY)    - Group array items by field
   group_count(KEY) - Count grouped items by field

--- a/t/abs.t
+++ b/t/abs.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "number": -10,
+  "numbers": [-3, 4, -5, "n/a"]
+});
+
+my $jq = JQ::Lite->new;
+
+my @scalar = $jq->run_query($json, '.number | abs');
+is($scalar[0], 10, 'abs converts scalar numbers to absolute value');
+
+my @array = $jq->run_query($json, '.numbers | abs');
+is_deeply(
+    $array[0],
+    [3, 4, 5, 'n/a'],
+    'abs converts numeric array entries and leaves non-numeric intact'
+);
+
+done_testing;


### PR DESCRIPTION
## Summary
- add an abs() helper to JQ::Lite to normalize numeric values and update the module documentation
- document the new helper in README and CLI help text and bump the version history
- cover scalar and array usage with a dedicated regression test and update the manifest

## Testing
- prove -l t/abs.t

------
https://chatgpt.com/codex/tasks/task_e_68e0c48eb1b48330855ff445347d3e54