### PR TITLE
Add trim() helper for whitespace normalization

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+0.50  2025-10-05
+    - Added trim() helper to remove leading/trailing whitespace from strings
+      and array elements recursively.
+    - Documented the new function and included it in the --help-functions
+      listing and README feature table.
+    - Added regression tests covering scalar, array, and mixed inputs.
+
 0.49  2025-10-04
     - Added abs() helper to convert numbers (and arrays of numbers) to their
       absolute values.

--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-0.50  2025-10-05
+0.50  2025-10-04
     - Added trim() helper to remove leading/trailing whitespace from strings
       and array elements recursively.
     - Documented the new function and included it in the --help-functions
@@ -237,6 +237,7 @@
     - Removed use of eval in _evaluate_condition for better performance and stability.
     - Refactored _traverse for readability and maintainability.
     - Added support for multi-level array traversal (e.g., .users[].friends[].name).
+
 
 
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -30,5 +30,6 @@ t/pluck.t
 t/reverse.t
 t/sort_by.t
 t/sort_unique.t
+t/trim.t
 t/values.t
 LICENSE

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `empty()`, `median`, `upper()`, `lower()`, `abs()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `trim()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -57,6 +57,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `add`, `min`, `max`, `avg`, `median` | Numeric aggregation functions            |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
+| `trim`        | Remove leading/trailing whitespace from strings (v0.50) |
 | `group_by(key)`| Group array items by field                           |
 | `group_count(key)` | Count how many items fall under each key (v0.46)   |
 | `count`        | Count total number of matching items                 |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -353,6 +353,7 @@ Supported Functions:
   is_empty         - Check if an array or object is empty
   upper()          - Convert scalars and array elements to uppercase
   lower()          - Convert scalars and array elements to lowercase
+  trim()           - Strip leading/trailing whitespace from strings (recurses into arrays)
   empty            - Discard all output (for side-effect use)
   type()           - Return the type of value ("string", "number", "boolean", "array", "object", "null")
   default(VALUE)   - Substitute VALUE when result is undefined

--- a/t/trim.t
+++ b/t/trim.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "title": "  Hello World  ",
+  "tags": [" perl ", "json ", "cli"],
+  "score": 5,
+  "mixed": [" spaced ", null, {"keep": "  untouched  "}]
+});
+
+my $jq = JQ::Lite->new;
+
+my @trimmed_title = $jq->run_query($json, '.title | trim');
+is($trimmed_title[0], 'Hello World', 'trim removes leading and trailing spaces from scalar');
+
+my @trimmed_tags = $jq->run_query($json, '.tags | trim');
+is_deeply($trimmed_tags[0], ['perl', 'json', 'cli'], 'trim applies recursively to array elements');
+
+my @number = $jq->run_query($json, '.score | trim');
+ok(!ref $number[0], 'trim leaves numeric scalar as non-reference');
+is($number[0], 5, 'trim leaves non-string scalars untouched');
+
+my @mixed = $jq->run_query($json, '.mixed | trim');
+is_deeply(
+    $mixed[0],
+    ['spaced', undef, { keep => '  untouched  ' }],
+    'trim recurses into arrays but leaves hashes as-is'
+);
+
+like($trimmed_title[0], qr/^\S.*\S$/, 'result has no surrounding whitespace');
+
+note('ensure undef input stays undef');
+my @defaulted = $jq->run_query($json, '.missing? | trim | default("fallback")');
+is($defaulted[0], 'fallback', 'trim preserves undef before default() substitution');
+
+note('trim can be chained with other functions');
+my @chained = $jq->run_query($json, '.tags | trim | first');
+is($chained[0], 'perl', 'trim result works with other filters');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a trim() built-in function that strips leading/trailing whitespace, update documentation, and bump the module version to 0.50
- list the new helper in the CLI --help output and README feature table
- add regression coverage for trim() and include the test in the MANIFEST

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e0c6a2bcf8833097c3a8ac1b655353