### PR TITLE
Add startswith/endswith string predicates

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.51  2025-10-05
+    - Added startswith()/endswith() helpers for prefix and suffix checks on
+      scalars and arrays of strings.
+    - Documented the new functions and listed them in README and --help-functions output.
+    - Added regression tests covering scalars, arrays, mixed values, and chained usage.
+
 0.50  2025-10-04
     - Added trim() helper to remove leading/trailing whitespace from strings
       and array elements recursively.

--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-0.51  2025-10-05
+0.51  2025-10-04
     - Added startswith()/endswith() helpers for prefix and suffix checks on
       scalars and arrays of strings.
     - Documented the new functions and listed them in README and --help-functions output.
@@ -243,6 +243,7 @@
     - Removed use of eval in _evaluate_condition for better performance and stability.
     - Refactored _traverse for readability and maintainability.
     - Added support for multi-level array traversal (e.g., .users[].friends[].name).
+
 
 
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -30,6 +30,7 @@ t/pluck.t
 t/reverse.t
 t/sort_by.t
 t/sort_unique.t
+t/startswith_endswith.t
 t/trim.t
 t/values.t
 LICENSE

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `trim()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -58,6 +58,8 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `add`, `min`, `max`, `avg`, `median` | Numeric aggregation functions            |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
 | `trim`        | Remove leading/trailing whitespace from strings (v0.50) |
+| `startswith(prefix)` | Check if a string (or array of strings) begins with `prefix` (v0.51) |
+| `endswith(suffix)` | Check if a string (or array of strings) ends with `suffix` (v0.51) |
 | `group_by(key)`| Group array items by field                           |
 | `group_count(key)` | Count how many items fall under each key (v0.46)   |
 | `count`        | Count total number of matching items                 |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -354,6 +354,8 @@ Supported Functions:
   upper()          - Convert scalars and array elements to uppercase
   lower()          - Convert scalars and array elements to lowercase
   trim()           - Strip leading/trailing whitespace from strings (recurses into arrays)
+  startswith(PFX)  - Check if a string (or array of strings) begins with PFX
+  endswith(SFX)    - Check if a string (or array of strings) ends with SFX
   empty            - Discard all output (for side-effect use)
   type()           - Return the type of value ("string", "number", "boolean", "array", "object", "null")
   default(VALUE)   - Substitute VALUE when result is undefined

--- a/t/startswith_endswith.t
+++ b/t/startswith_endswith.t
@@ -1,0 +1,79 @@
+use strict;
+use warnings;
+use Test::More;
+use JSON::PP;
+use JQ::Lite;
+
+my $json = q({
+  "title": "Hello World!",
+  "tags": ["perl", "json", "cli"],
+  "names": ["Alice", "Bob", "Alfred"],
+  "mixed": ["prefix", null, 123, {"key": "value"}]
+});
+
+my $jq = JQ::Lite->new;
+
+my @starts_title = $jq->run_query($json, '.title | startswith("Hello")');
+ok($starts_title[0], 'startswith() returns true for matching prefix');
+
+my @starts_false = $jq->run_query($json, '.title | startswith("World")');
+ok(!$starts_false[0], 'startswith() returns false when prefix does not match');
+
+my @ends_title = $jq->run_query($json, '.title | endswith("World!")');
+ok($ends_title[0], 'endswith() returns true for matching suffix');
+
+my @ends_false = $jq->run_query($json, '.title | endswith("Hello")');
+ok(!$ends_false[0], 'endswith() returns false when suffix does not match');
+
+my @array_prefix = $jq->run_query($json, '.names | startswith("Al")');
+is_deeply(
+    $array_prefix[0],
+    [JSON::PP::true, JSON::PP::false, JSON::PP::true],
+    'startswith() maps over arrays and produces booleans'
+);
+
+my @array_suffix = $jq->run_query($json, '.names | endswith("ce")');
+is_deeply(
+    $array_suffix[0],
+    [JSON::PP::true, JSON::PP::false, JSON::PP::false],
+    'endswith() maps over arrays and produces booleans'
+);
+
+my @mixed_values = $jq->run_query($json, '.mixed | startswith("pre")');
+is_deeply(
+    $mixed_values[0],
+    [JSON::PP::true, JSON::PP::false, JSON::PP::false, JSON::PP::false],
+    'non-string values yield JSON false booleans'
+);
+
+my @empty_prefix = $jq->run_query($json, '.title | startswith("")');
+ok($empty_prefix[0], 'empty prefix always matches');
+
+my @empty_suffix = $jq->run_query($json, '.title | endswith("")');
+ok($empty_suffix[0], 'empty suffix always matches');
+
+my @default_chain = $jq->run_query($json, '.missing? | startswith("foo") | default("fallback")');
+is($default_chain[0], 'fallback', 'startswith() preserves undef values for default() to handle');
+
+my @array_empty = $jq->run_query($json, '.names | endswith("")');
+is_deeply(
+    $array_empty[0],
+    [JSON::PP::true, JSON::PP::true, JSON::PP::true],
+    'empty suffix returns true for every string in array'
+);
+
+my @case_sensitive = $jq->run_query($json, '.tags | startswith("P")');
+is_deeply(
+    $case_sensitive[0],
+    [JSON::PP::false, JSON::PP::false, JSON::PP::false],
+    'startswith() remains case-sensitive'
+);
+
+my @trim_chain = $jq->run_query($json, '.tags | trim | endswith("n")');
+is_deeply(
+    $trim_chain[0],
+    [JSON::PP::false, JSON::PP::true, JSON::PP::false],
+    'endswith() composes with other filters like trim()'
+);
+
+done_testing;


### PR DESCRIPTION
## Summary
- add `startswith()` and `endswith()` string helpers with array support to the query engine
- document the new predicates in the module POD, README, CLI help, and release notes
- extend the test suite and manifest to cover the new functionality

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e0c8e607a48330b05ed65a1c1df303