### PR TITLE
Add split() helper for string separators

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.52  2025-10-05
+    - Added split() helper for splitting string values by a literal separator.
+    - Documented the new function in README, POD, and --help-functions output.
+    - Added regression tests covering scalar strings, nested arrays, and edge cases.
+
 0.51  2025-10-04
     - Added startswith()/endswith() helpers for prefix and suffix checks on
       scalars and arrays of strings.

--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-0.52  2025-10-05
+0.52  2025-10-04
     - Added split() helper for splitting string values by a literal separator.
     - Documented the new function in README, POD, and --help-functions output.
     - Added regression tests covering scalar strings, nested arrays, and edge cases.
@@ -248,6 +248,7 @@
     - Removed use of eval in _evaluate_condition for better performance and stability.
     - Refactored _traverse for readability and maintainability.
     - Added support for multi-level array traversal (e.g., .users[].friends[].name).
+
 
 
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -28,6 +28,7 @@ t/match_i.t
 t/pipe_select_name.t
 t/pluck.t
 t/reverse.t
+t/split.t
 t/sort_by.t
 t/sort_unique.t
 t/startswith_endswith.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `trim()`, `startswith()`, `endswith()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -60,6 +60,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `trim`        | Remove leading/trailing whitespace from strings (v0.50) |
 | `startswith(prefix)` | Check if a string (or array of strings) begins with `prefix` (v0.51) |
 | `endswith(suffix)` | Check if a string (or array of strings) ends with `suffix` (v0.51) |
+| `split(separator)` | Split a string (or array of strings) using a literal separator (v0.52) |
 | `group_by(key)`| Group array items by field                           |
 | `group_count(key)` | Count how many items fall under each key (v0.46)   |
 | `count`        | Count total number of matching items                 |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -343,6 +343,7 @@ Supported Functions:
   group_by(KEY)    - Group array items by field
   group_count(KEY) - Count grouped items by field
   join(SEPARATOR)  - Join array elements with a string
+  split(SEPARATOR) - Split string values (and arrays of strings) by a literal separator
   has              - Check if object has a given key
   contains         - Check if array or string contains a value
   match("pattern") - Match string using regex

--- a/t/split.t
+++ b/t/split.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "text": "foo,bar,baz",
+  "users": [
+    { "name": "Alice" },
+    { "name": "Bob" }
+  ],
+  "mixed": ["alpha beta", null, ["inner"], {"skip": "value"}],
+  "trailing": "tail,",
+  "dots": "a.b.c"
+});
+
+my $jq = JQ::Lite->new;
+
+my @comma = $jq->run_query($json, '.text | split(",")');
+is_deeply($comma[0], [qw(foo bar baz)], 'split(",") breaks comma-separated string');
+
+my @chars = $jq->run_query($json, '.users[0].name | split("")');
+is_deeply($chars[0], [qw(A l i c e)], 'split("") returns individual characters');
+
+my @array = $jq->run_query($json, '.mixed | split(" ")');
+my $expected = [
+    [qw(alpha beta)],
+    [],
+    [[qw(inner)]],
+    { skip => 'value' },
+];
+is_deeply($array[0], $expected, 'split applies recursively to arrays and keeps non-strings untouched');
+
+my @literal = $jq->run_query($json, '.dots | split(".")');
+is_deeply($literal[0], [qw(a b c)], 'split uses literal separator rather than regex');
+
+my @trailing = $jq->run_query($json, '.trailing | split(",")');
+is_deeply($trailing[0], ['tail', ''], 'split preserves trailing empty fields');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a split() built-in that splits string results (and arrays of strings) by a literal separator
- document the new helper across the README, POD, Changes log, and --help-functions output
- cover the behaviour with new regression tests and list the test in the MANIFEST

## Testing
- prove -l t/split.t
- prove -l t

------
https://chatgpt.com/codex/tasks/task_e_68e0cb3898f083309767a345e35aab5e