### PR TITLE
Add ceil() and floor() numeric rounding helpers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.53  2025-10-05
+    - Added ceil()/floor() helpers for rounding numeric scalars and arrays.
+    - Documented the new functions in README, POD, and --help-functions output.
+    - Added regression tests for positive/negative values and nested arrays.
+
 0.52  2025-10-04
     - Added split() helper for splitting string values by a literal separator.
     - Documented the new function in README, POD, and --help-functions output.

--- a/MANIFEST
+++ b/MANIFEST
@@ -11,6 +11,7 @@ t/arithmetic.t
 t/basic.t
 t/contains.t
 t/case_transform.t
+t/ceil_floor.t
 t/count.t
 t/empty.t
 t/first_last.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `trim()`, `startswith()`, `endswith()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -57,6 +57,8 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `add`, `min`, `max`, `avg`, `median` | Numeric aggregation functions            |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
+| `ceil`        | Round numbers up to the nearest integer (v0.53)        |
+| `floor`       | Round numbers down to the nearest integer (v0.53)      |
 | `trim`        | Remove leading/trailing whitespace from strings (v0.50) |
 | `startswith(prefix)` | Check if a string (or array of strings) begins with `prefix` (v0.51) |
 | `endswith(suffix)` | Check if a string (or array of strings) ends with `suffix` (v0.51) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -339,6 +339,8 @@ Supported Functions:
   avg              - Return the average of numeric values in an array
   median           - Return the median of numeric values in an array
   abs              - Convert numbers (and array elements) to their absolute value
+  ceil()           - Round numbers up to the nearest integer
+  floor()          - Round numbers down to the nearest integer
   nth(N)           - Get the Nth element of an array (zero-based index)
   group_by(KEY)    - Group array items by field
   group_count(KEY) - Count grouped items by field

--- a/t/ceil_floor.t
+++ b/t/ceil_floor.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "price": 19.2,
+  "debt": -1.7,
+  "numbers": [1.1, -1.1, "n/a", null, [2.3, -2.3]]
+});
+
+my $jq = JQ::Lite->new;
+
+my @ceil_price = $jq->run_query($json, '.price | ceil');
+is($ceil_price[0], 20, 'ceil rounds positive scalar up');
+
+my @ceil_debt = $jq->run_query($json, '.debt | ceil');
+is($ceil_debt[0], -1, 'ceil rounds negative scalar toward zero');
+
+my @ceil_values = $jq->run_query($json, '.numbers | ceil');
+is_deeply(
+    $ceil_values[0],
+    [2, -1, 'n/a', undef, [3, -2]],
+    'ceil processes arrays recursively and leaves non-numeric values untouched'
+);
+
+my @floor_price = $jq->run_query($json, '.price | floor');
+is($floor_price[0], 19, 'floor rounds positive scalar down');
+
+my @floor_debt = $jq->run_query($json, '.debt | floor');
+is($floor_debt[0], -2, 'floor rounds negative scalar away from zero');
+
+my @floor_values = $jq->run_query($json, '.numbers | floor');
+is_deeply(
+    $floor_values[0],
+    [1, -2, 'n/a', undef, [2, -3]],
+    'floor processes arrays recursively and leaves non-numeric values untouched'
+);
+
+
+done_testing;


### PR DESCRIPTION
## Summary
- add ceil() and floor() pipeline helpers that reuse a shared numeric transformer
- document the new rounding functions across README, module POD, CLI help, and changelog
- cover the new behaviour with regression tests and update the manifest

## Testing
- prove -l

------
https://chatgpt.com/codex/tasks/task_e_68e0cd1b37648330b1105905ad447254