### PR TITLE
Extend length to support scalars

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.55 2025-04-06
+    [Feature]
+    - Updated length function to return character counts for scalars in addition to
+      array elements and hash keys.
+
 0.54  2025-10-04
     - Added round() helper for rounding numbers (and arrays) to the nearest integer.
     - Documented the new function in README, POD, and --help-functions output.

--- a/MANIFEST
+++ b/MANIFEST
@@ -22,6 +22,7 @@ t/group_count.t
 t/has.t
 t/join.t
 t/limit.t
+t/length.t
 t/map.t
 t/median.t
 t/match.t

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 
 | Function       | Description                                           |
 |----------------|-------------------------------------------------------|
-| `length`       | Get number of elements in an array or keys in a hash |
+| `length`       | Get number of elements in an array, keys in a hash, or characters in scalars |
 | `keys`         | Extract sorted keys from a hash                      |
 | `values`       | Extract values from a hash (v0.34)                   |
 | `sort`         | Sort array items                                     |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -322,7 +322,7 @@ sub print_supported_functions {
     print <<'EOF';
 
 Supported Functions:
-  length           - Get number of elements in an array or keys in a hash
+  length           - Count array elements, hash keys, or characters in scalars
   keys             - Extract sorted keys from a hash
   values           - Extract values from a hash (v0.34)
   sort             - Sort array items

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -6,7 +6,7 @@ use JSON::PP;
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 
-our $VERSION = '0.54';
+our $VERSION = '0.55';
 
 sub new {
     my ($class, %opts) = @_;
@@ -62,9 +62,21 @@ sub run_query {
         # support for length
         if ($part eq 'length') {
             @next_results = map {
-                ref $_ eq 'ARRAY' ? scalar(@$_) :
-                ref $_ eq 'HASH'  ? scalar(keys %$_) :
-                0
+                if (!defined $_) {
+                    0;
+                }
+                elsif (ref $_ eq 'ARRAY') {
+                    scalar(@$_);
+                }
+                elsif (ref $_ eq 'HASH') {
+                    scalar(keys %$_);
+                }
+                elsif (!ref $_ || ref($_) eq 'JSON::PP::Boolean') {
+                    length("$_");
+                }
+                else {
+                    0;
+                }
             } @results;
             @results = @next_results;
             next;
@@ -974,7 +986,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 0.54
+Version 0.55
 
 =head1 SYNOPSIS
 

--- a/t/length.t
+++ b/t/length.t
@@ -1,0 +1,29 @@
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "arr": [1, 2, 3],
+  "obj": {"a": 1, "b": 2},
+  "str": "hello",
+  "num": 12345,
+  "bool": true,
+  "null": null
+});
+
+my $jq = JQ::Lite->new;
+
+my @arr = $jq->run_query($json, '.arr | length');
+my @obj = $jq->run_query($json, '.obj | length');
+my @str = $jq->run_query($json, '.str | length');
+my @num = $jq->run_query($json, '.num | length');
+my @bool = $jq->run_query($json, '.bool | length');
+my @null = $jq->run_query($json, '.null | length');
+
+is($arr[0], 3, 'array length counts elements');
+is($obj[0], 2, 'object length counts keys');
+is($str[0], 5, 'string length counts characters');
+is($num[0], 5, 'numeric length counts digits');
+is($bool[0], 1, 'boolean length is treated as scalar');
+is($null[0], 0, 'null length is zero');
+
+done_testing;


### PR DESCRIPTION
## Summary
- update the length builtin to return character counts for scalar values and bump the module version to 0.55
- document the enhanced behavior in the changelog, README, and CLI help text
- add regression coverage ensuring length works for arrays, objects, strings, numbers, booleans, and null values

## Testing
- prove -l t

------
https://chatgpt.com/codex/tasks/task_e_68e0d0aca9c8833082953fe813ddb7eb