### PR TITLE
Add contains() built-in helper

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.56  2025-10-04
+    [Feature]
+    - Added contains() function for substring, array element, and hash key checks.
+    - Documented the new helper and covered it with regression tests.
+
 0.55  2025-10-04
     [Feature]
     - Updated length function to return character counts for scalars in addition to

--- a/MANIFEST
+++ b/MANIFEST
@@ -10,6 +10,7 @@ t/aggregate.t
 t/arithmetic.t
 t/basic.t
 t/contains.t
+t/contains_function.t
 t/case_transform.t
 t/ceil_floor.t
 t/count.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -64,6 +64,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `startswith(prefix)` | Check if a string (or array of strings) begins with `prefix` (v0.51) |
 | `endswith(suffix)` | Check if a string (or array of strings) ends with `suffix` (v0.51) |
 | `split(separator)` | Split a string (or array of strings) using a literal separator (v0.52) |
+| `contains(value)` | Check whether strings include the value or arrays contain an element (v0.56) |
 | `group_by(key)`| Group array items by field                           |
 | `group_count(key)` | Count how many items fall under each key (v0.46)   |
 | `count`        | Count total number of matching items                 |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -348,7 +348,7 @@ Supported Functions:
   join(SEPARATOR)  - Join array elements with a string
   split(SEPARATOR) - Split string values (and arrays of strings) by a literal separator
   has              - Check if object has a given key
-  contains         - Check if array or string contains a value
+  contains         - Check if strings include a fragment, arrays contain an element, or hashes have a key
   match("pattern") - Match string using regex
   flatten          - Explicitly flatten arrays (same as .[])
   del(KEY)         - Remove a key from objects in the result

--- a/t/contains_function.t
+++ b/t/contains_function.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "tags": ["perl", "json", "cli"],
+  "title": "jq-lite in perl",
+  "meta": {"lang": "perl", "stable": true},
+  "numbers": [1, 2, 3],
+  "missing": null
+});
+
+my $jq = JQ::Lite->new;
+
+my @tag_true  = $jq->run_query($json, '.tags | contains("perl")');
+my @tag_false = $jq->run_query($json, '.tags | contains("python")');
+my @num_true  = $jq->run_query($json, '.numbers | contains(2)');
+my @title_true = $jq->run_query($json, '.title | contains("perl")');
+my @meta_true  = $jq->run_query($json, '.meta | contains("lang")');
+my @missing    = $jq->run_query($json, '.missing | contains("anything")');
+
+ok($tag_true[0], 'array contains existing value');
+ok(!$tag_false[0], 'array does not contain missing value');
+ok($num_true[0], 'numeric array contains number');
+ok($title_true[0], 'string contains substring');
+ok($meta_true[0], 'hash contains key');
+ok(!$missing[0], 'null value does not contain substring');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a contains() helper that supports substring, array element, and hash key checks in queries
- document the new function in the README, module POD, and CLI help output
- add regression coverage for contains() and update release notes

## Testing
- prove -l

------
https://chatgpt.com/codex/tasks/task_e_68e0d2eaaf4483308000cf043007f44c