### PR TITLE
Add sum helper for jq compatibility

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.58  2025-10-05
+    [Feature]
+    - Added sum helper as an alias for add to provide jq-compatible naming.
+    - Documented the new helper across README, POD, and --help-functions output.
+    - Extended aggregation tests to cover the new function.
+
 0.57  2025-10-04
     [Feature]
     - Added substr(start, length) helper to extract substrings from scalars and

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `empty()`, `median`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `empty()`, `median`, `add`, `sum`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -55,7 +55,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `limit(n)`     | Limit array to first `n` elements                    |
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
-| `add`, `min`, `max`, `avg`, `median` | Numeric aggregation functions            |
+| `add`, `sum`, `min`, `max`, `avg`, `median` | Numeric aggregation functions            |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
 | `ceil`        | Round numbers up to the nearest integer (v0.53)        |
 | `floor`       | Round numbers down to the nearest integer (v0.53)      |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -334,7 +334,7 @@ Supported Functions:
   limit(N)         - Limit array to first N elements
   count            - Count total number of matching items
   map(EXPR)        - Map/filter array items with a subquery
-  add              - Sum all numeric values in an array
+  add / sum        - Sum all numeric values in an array
   min / max        - Return minimum / maximum numeric value in an array
   avg              - Return the average of numeric values in an array
   median           - Return the median of numeric values in an array

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -6,7 +6,7 @@ use JSON::PP;
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 
-our $VERSION = '0.57';
+our $VERSION = '0.58';
 
 sub new {
     my ($class, %opts) = @_;
@@ -190,6 +190,15 @@ sub run_query {
 
         # support for add
         if ($part eq 'add') {
+            @next_results = map {
+                ref $_ eq 'ARRAY' ? sum(map { 0 + $_ } @$_) : $_
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for sum (alias for add)
+        if ($part eq 'sum') {
             @next_results = map {
                 ref $_ eq 'ARRAY' ? sum(map { 0 + $_ } @$_) : $_
             } @results;
@@ -1100,7 +1109,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 0.56
+Version 0.58
 
 =head1 SYNOPSIS
 
@@ -1137,7 +1146,7 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_by, unique, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith
+=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_by, unique, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, min, max, avg, median
 
 =item * Supports map(...) and limit(n) style transformations
 

--- a/t/aggregate.t
+++ b/t/aggregate.t
@@ -14,6 +14,9 @@ my $jq = JQ::Lite->new;
 my ($add) = $jq->run_query($json, 'map(.value) | add');
 is($add, 60, 'add = 60');
 
+my ($sum) = $jq->run_query($json, 'map(.value) | sum');
+is($sum, 60, 'sum = 60');
+
 my ($min) = $jq->run_query($json, 'map(.value) | min');
 is($min, 10, 'min = 10');
 


### PR DESCRIPTION
## Summary
- add a `sum` helper so jq-style queries map directly onto the aggregation helpers
- document the new alias across the README, POD, and CLI help output
- extend the aggregation test suite to cover the new helper

## Testing
- prove -l t/


------
https://chatgpt.com/codex/tasks/task_e_68e19945fb7c8330a287c1c899817b87