### PR TITLE
Add product aggregation helper

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-0.59  2025-10-06
+0.59  2025-10-05
     [Feature]
     - Added product helper to multiply numeric array values.
     - Documented the helper across README, POD, and --help-functions output.
@@ -288,6 +288,7 @@
     - Removed use of eval in _evaluate_condition for better performance and stability.
     - Refactored _traverse for readability and maintainability.
     - Added support for multi-level array traversal (e.g., .users[].friends[].name).
+
 
 
 

--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.59  2025-10-06
+    [Feature]
+    - Added product helper to multiply numeric array values.
+    - Documented the helper across README, POD, and --help-functions output.
+    - Extended aggregation tests to cover the new helper.
+
 0.58  2025-10-05
     [Feature]
     - Added sum helper as an alias for add to provide jq-compatible naming.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `add`, `sum`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -55,7 +55,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `limit(n)`     | Limit array to first `n` elements                    |
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
-| `add`, `sum`, `min`, `max`, `avg`, `median` | Numeric aggregation functions            |
+| `add`, `sum`, `min`, `max`, `avg`, `median`, `product` | Numeric aggregation functions            |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
 | `ceil`        | Round numbers up to the nearest integer (v0.53)        |
 | `floor`       | Round numbers down to the nearest integer (v0.53)      |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -335,6 +335,7 @@ Supported Functions:
   count            - Count total number of matching items
   map(EXPR)        - Map/filter array items with a subquery
   add / sum        - Sum all numeric values in an array
+  product          - Multiply all numeric values in an array
   min / max        - Return minimum / maximum numeric value in an array
   avg              - Return the average of numeric values in an array
   median           - Return the median of numeric values in an array

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -6,7 +6,7 @@ use JSON::PP;
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 
-our $VERSION = '0.58';
+our $VERSION = '0.59';
 
 sub new {
     my ($class, %opts) = @_;
@@ -201,6 +201,26 @@ sub run_query {
         if ($part eq 'sum') {
             @next_results = map {
                 ref $_ eq 'ARRAY' ? sum(map { 0 + $_ } @$_) : $_
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for product
+        if ($part eq 'product') {
+            @next_results = map {
+                if (ref $_ eq 'ARRAY') {
+                    my $product    = 1;
+                    my $has_values = 0;
+                    for my $val (@$_) {
+                        next unless defined $val;
+                        $product *= (0 + $val);
+                        $has_values = 1;
+                    }
+                    $has_values ? $product : 1;
+                } else {
+                    $_;
+                }
             } @results;
             @results = @next_results;
             next;
@@ -1142,7 +1162,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 0.58
+Version 0.59
 
 =head1 SYNOPSIS
 
@@ -1179,7 +1199,7 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_by, unique, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, min, max, avg, median
+=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_by, unique, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, product, min, max, avg, median
 
 =item * Supports map(...) and limit(n) style transformations
 

--- a/t/aggregate.t
+++ b/t/aggregate.t
@@ -26,4 +26,7 @@ is($max, 30, 'max = 30');
 my ($avg) = $jq->run_query($json, 'map(.value) | avg');
 is($avg, 20, 'avg = 20');
 
+my ($product) = $jq->run_query($json, 'map(.value) | product');
+is($product, 6000, 'product = 6000');
+
 done_testing;


### PR DESCRIPTION
## Summary
- add a product aggregation helper that multiplies numeric array values
- document the new helper across README, POD, and the CLI help listing
- extend the aggregation regression test to cover the new helper

## Testing
- prove -l t/

------
https://chatgpt.com/codex/tasks/task_e_68e19ccb14548330bdda9c5735957bab