### PR TITLE
Add unique_by helper for keyed deduplication

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.60  2025-10-06
+    [Feature]
+    - Added unique_by(key) helper to deduplicate arrays based on projected keys.
+    - Documented the helper across README, POD, and --help-functions output.
+    - Added regression tests covering scalar, object, and nested-key scenarios.
+
 0.59  2025-10-05
     [Feature]
     - Added product helper to multiply numeric array values.

--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-0.60  2025-10-06
+0.60  2025-10-05
     [Feature]
     - Added unique_by(key) helper to deduplicate arrays based on projected keys.
     - Documented the helper across README, POD, and --help-functions output.
@@ -294,6 +294,7 @@
     - Removed use of eval in _evaluate_condition for better performance and stability.
     - Refactored _traverse for readability and maintainability.
     - Added support for multi-level array traversal (e.g., .users[].friends[].name).
+
 
 
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -38,6 +38,7 @@ t/sort_by.t
 t/sort_unique.t
 t/substr.t
 t/startswith_endswith.t
+t/unique_by.t
 t/trim.t
 t/values.t
 LICENSE

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -49,6 +49,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `sort`         | Sort array items                                     |
 | `sort_by(key)` | Sort array of objects by field (v0.32)               |
 | `unique`       | Remove duplicate values                              |
+| `unique_by(path)` | Remove duplicates by projecting each entry to a key path (v0.60) |
 | `first`        | Get the first element of an array                    |
 | `last`         | Get the last element of an array                     |
 | `reverse`      | Reverse an array                                     |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -329,6 +329,7 @@ Supported Functions:
   sort_by(KEY)     - Sort array of objects by key
   pluck(KEY)       - Collect a key's value from each object in an array
   unique           - Remove duplicate values
+  unique_by(KEY)   - Remove duplicates by projecting each item on KEY
   reverse          - Reverse an array
   first / last     - Get first / last element of an array
   limit(N)         - Limit array to first N elements

--- a/t/unique_by.t
+++ b/t/unique_by.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = <<'JSON';
+{
+  "users": [
+    { "name": "Alice", "city": "Tokyo" },
+    { "name": "Bob",   "city": "Osaka" },
+    { "name": "Alice", "city": "Kyoto" },
+    { "name": "Charlie", "city": "Nagoya" }
+  ],
+  "numbers": [1, 2, 1, 3, 2],
+  "nested": [
+    { "meta": { "id": 1 }, "value": "first" },
+    { "meta": { "id": 1 }, "value": "duplicate" },
+    { "meta": { "id": 2 }, "value": "unique" }
+  ]
+}
+JSON
+
+my $jq = JQ::Lite->new;
+
+my @by_name = $jq->run_query($json, '.users | unique_by(.name) | map(.name)');
+is_deeply(
+    \@by_name,
+    [['Alice', 'Bob', 'Charlie']],
+    'unique_by(.name) keeps the first occurrence for each projected name',
+);
+
+my @by_self = $jq->run_query($json, '.numbers | unique_by(.)');
+is_deeply(
+    \@by_self,
+    [[1, 2, 3]],
+    'unique_by(.) removes duplicate scalars while preserving order',
+);
+
+my @by_nested = $jq->run_query($json, '.nested | unique_by(.meta.id) | map(.value)');
+is_deeply(
+    \@by_nested,
+    [['first', 'unique']],
+    'unique_by(.meta.id) deduplicates using nested keys',
+);
+
+done_testing();


### PR DESCRIPTION
## Summary
- add a unique_by(path) helper that deduplicates arrays by projected keys and bump the module version
- document the new helper across README, POD, CLI help, and changelog entries
- cover the behaviour with regression tests and include the test file in the manifest

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e19e88e9b8833087dd1725436c6080