### PR TITLE
Add sort_desc helper

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+0.61  2025-10-05
+    [Feature]
+    - Added sort_desc helper to sort arrays in descending order using smart
+      numeric/string comparisons.
+    - Documented the helper across README, POD, and --help-functions output.
+    - Added regression tests covering numeric, string, and numeric-string values.
+
 0.60  2025-10-05
     [Feature]
     - Added unique_by(key) helper to deduplicate arrays based on projected keys.

--- a/MANIFEST
+++ b/MANIFEST
@@ -33,6 +33,7 @@ t/pluck.t
 t/reverse.t
 t/replace.t
 t/round.t
+t/sort_desc.t
 t/split.t
 t/sort_by.t
 t/sort_unique.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -47,6 +47,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `keys`         | Extract sorted keys from a hash                      |
 | `values`       | Extract values from a hash (v0.34)                   |
 | `sort`         | Sort array items                                     |
+| `sort_desc`    | Sort array items in descending order (v0.61)         |
 | `sort_by(key)` | Sort array of objects by field (v0.32)               |
 | `unique`       | Remove duplicate values                              |
 | `unique_by(path)` | Remove duplicates by projecting each entry to a key path (v0.60) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -326,6 +326,7 @@ Supported Functions:
   keys             - Extract sorted keys from a hash
   values           - Extract values from a hash (v0.34)
   sort             - Sort array items
+  sort_desc        - Sort array items in descending order
   sort_by(KEY)     - Sort array of objects by key
   pluck(KEY)       - Collect a key's value from each object in an array
   unique           - Remove duplicate values

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -6,7 +6,7 @@ use JSON::PP;
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 
-our $VERSION = '0.60';
+our $VERSION = '0.61';
 
 sub new {
     my ($class, %opts) = @_;
@@ -95,6 +95,21 @@ sub run_query {
         if ($part eq 'sort') {
             @next_results = map {
                 ref $_ eq 'ARRAY' ? [ sort { _smart_cmp()->($a, $b) } @$_ ] : $_
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for sort_desc
+        if ($part eq 'sort_desc') {
+            @next_results = map {
+                if (ref $_ eq 'ARRAY') {
+                    my $cmp = _smart_cmp();
+                    [ sort { $cmp->($b, $a) } @$_ ];
+                }
+                else {
+                    $_;
+                }
             } @results;
             @results = @next_results;
             next;
@@ -1209,7 +1224,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 0.60
+Version 0.61
 
 =head1 SYNOPSIS
 
@@ -1246,7 +1261,7 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, product, min, max, avg, median
+=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_desc, sort_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, product, min, max, avg, median
 
 =item * Supports map(...) and limit(n) style transformations
 
@@ -1297,6 +1312,18 @@ Returns a list of matched results. Each result is a Perl scalar
 =item * group_by(.field) (group array items by key)
 
 =item * group_count(.field) (tally items by key)
+
+=item * sort_desc()
+
+Sort array elements in descending order using smart numeric/string comparison.
+
+Example:
+
+  .scores | sort_desc
+
+Returns:
+
+  [100, 75, 42, 12]
 
 =item * sort_by(.key) (sort array of objects by key)
 

--- a/t/sort_desc.t
+++ b/t/sort_desc.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "nums": [1, 9, 3, 2],
+  "words": ["apple", "pear", "banana"],
+  "mixed": ["10", "2", "30"]
+});
+
+my $jq = JQ::Lite->new;
+
+my @desc_nums   = $jq->run_query($json, '.nums | sort_desc');
+my @desc_words  = $jq->run_query($json, '.words | sort_desc');
+my @desc_mixed  = $jq->run_query($json, '.mixed | sort_desc');
+
+is_deeply($desc_nums[0],  [9, 3, 2, 1], 'numeric sort descending');
+is_deeply($desc_words[0], ['pear', 'banana', 'apple'], 'string sort descending');
+is_deeply($desc_mixed[0], ['30', '10', '2'], 'smart comparison honors numeric values');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a `sort_desc` helper that sorts array results in descending order with smart numeric/string comparison
- document the new function across the README, pod, CLI help, and changelog while bumping the module version to 0.61
- add regression tests for descending sorting and include them in the manifest

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e1a099ae84833086cee0c80357055c