### PR TITLE
Add support for negative array indices

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+0.62  2025-10-05
+    [Feature]
+    - Added support for negative array indices (e.g. .users[-1]) across
+      queries and the nth() helper.
+    - Documented the new capability in README and module POD.
+    - Added regression tests covering backwards indexing and nth(-1).
+
 0.61  2025-10-05
     [Feature]
     - Added sort_desc helper to sort arrays in descending order using smart

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ **Pure Perl** (no XS, no external binaries)
 - ✅ Dot notation (`.users[].name`)
 - ✅ Optional key access (`.nickname?`)
-- ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
+- ✅ Array indexing and expansion (`.users[0]`, `.users[]`, `.users[-1]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
 - ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
@@ -249,6 +249,7 @@ jq-lite '.users | map(.name) | join(", ")' users.json
 jq-lite '.users[] | select(.age > 25) | empty' users.json
 jq-lite '.users[0] | values' users.json
 jq-lite '.users[0].name | type' users.json
+jq-lite '.users[-1].name' users.json
 ```
 
 ---

--- a/t/negative_indices.t
+++ b/t/negative_indices.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use JQ::Lite;
+
+my $object_json = <<'JSON';
+{
+  "users": [
+    { "name": "Alice", "age": 30 },
+    { "name": "Bob",   "age": 25 },
+    { "name": "Carol", "age": 35 }
+  ]
+}
+JSON
+
+my $array_json = <<'JSON';
+[
+  { "name": "Ann" },
+  { "name": "Bea" },
+  { "name": "Cal" }
+]
+JSON
+
+my $jq = JQ::Lite->new;
+
+is_deeply([
+    $jq->run_query($object_json, '.users[-1].name')
+], ['Carol'], 'negative index fetches last object');
+
+is_deeply([
+    $jq->run_query($object_json, '.users[-2].age')
+], [25], 'negative index fetches middle object');
+
+is_deeply([
+    $jq->run_query($object_json, '.users | nth(-1) | .name')
+], ['Carol'], 'nth(-1) returns last element');
+
+is_deeply([
+    $jq->run_query($object_json, '.users | nth(-4)')
+], [undef], 'nth(-4) returns undef when out of bounds');
+
+is_deeply([
+    $jq->run_query($array_json, '.[-1].name')
+], ['Cal'], 'negative index works on top-level array');
+
+is_deeply([
+    $jq->run_query($array_json, 'nth(-2) | .name')
+], ['Bea'], 'nth(-2) works on top-level array');
+
+done_testing();
+


### PR DESCRIPTION
## Summary
- allow negative indices in query traversal and nth() by normalizing array access
- document the new negative indexing support across README and module POD
- add regression coverage for negative index lookups and nth(-1)

## Testing
- prove -l t/

------
https://chatgpt.com/codex/tasks/task_e_68e1a24b56588330a3cc6ab62211ae05