### PR TITLE
Add stddev aggregation helper

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+0.62  2025-10-06
+    [Feature]
+    - Added stddev helper to calculate the standard deviation of numeric array
+      values.
+    - Documented the helper across README, POD, and --help-functions output.
+    - Added regression tests covering numeric, mixed, and single-value inputs.
+
 0.61  2025-10-05
     [Feature]
     - Added sort_desc helper to sort arrays in descending order using smart

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -57,7 +57,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `limit(n)`     | Limit array to first `n` elements                    |
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
-| `add`, `sum`, `min`, `max`, `avg`, `median`, `product` | Numeric aggregation functions            |
+| `add`, `sum`, `min`, `max`, `avg`, `median`, `stddev`, `product` | Numeric aggregation functions            |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
 | `ceil`        | Round numbers up to the nearest integer (v0.53)        |
 | `floor`       | Round numbers down to the nearest integer (v0.53)      |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -341,6 +341,7 @@ Supported Functions:
   min / max        - Return minimum / maximum numeric value in an array
   avg              - Return the average of numeric values in an array
   median           - Return the median of numeric values in an array
+  stddev           - Return the standard deviation of numeric values in an array
   abs              - Convert numbers (and array elements) to their absolute value
   ceil()           - Round numbers up to the nearest integer
   floor()          - Round numbers down to the nearest integer

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -6,7 +6,7 @@ use JSON::PP;
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 
-our $VERSION = '0.61';
+our $VERSION = '0.62';
 
 sub new {
     my ($class, %opts) = @_;
@@ -380,6 +380,32 @@ sub run_query {
                     $_;
                 }
             } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for stddev
+        if ($part eq 'stddev') {
+            @next_results = map {
+                if (ref $_ eq 'ARRAY') {
+                    my @numbers = map { 0 + $_ }
+                        grep { looks_like_number($_) }
+                        @$_;
+
+                    if (@numbers) {
+                        my $mean = sum(@numbers) / @numbers;
+                        my $variance = sum(map { ($_ - $mean) ** 2 } @numbers) / @numbers;
+                        sqrt($variance);
+                    }
+                    else {
+                        undef;
+                    }
+                }
+                else {
+                    $_;
+                }
+            } @results;
+
             @results = @next_results;
             next;
         }
@@ -1224,7 +1250,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 0.61
+Version 0.62
 
 =head1 SYNOPSIS
 
@@ -1261,7 +1287,7 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_desc, sort_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, product, min, max, avg, median
+=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_desc, sort_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, product, min, max, avg, median, stddev
 
 =item * Supports map(...) and limit(n) style transformations
 

--- a/t/aggregate.t
+++ b/t/aggregate.t
@@ -26,7 +26,16 @@ is($max, 30, 'max = 30');
 my ($avg) = $jq->run_query($json, 'map(.value) | avg');
 is($avg, 20, 'avg = 20');
 
+my ($stddev) = $jq->run_query($json, 'map(.value) | stddev');
+ok(abs($stddev - 8.1649658) < 1e-6, 'stddev approx 8.1649658');
+
 my ($product) = $jq->run_query($json, 'map(.value) | product');
 is($product, 6000, 'product = 6000');
+
+my ($stddev_single) = $jq->run_query(q([{ "value": 42 }]), 'map(.value) | stddev');
+is($stddev_single, 0, 'stddev of single value = 0');
+
+my ($stddev_non_numeric) = $jq->run_query(q(["alpha", "beta", "gamma"]), 'stddev');
+ok(!defined $stddev_non_numeric, 'stddev returns undef when array has no numeric values');
 
 done_testing;


### PR DESCRIPTION
## Summary
- add a stddev aggregation helper that computes the standard deviation for numeric arrays
- document the new helper across README, module POD, and command-line help output while bumping the version to 0.62
- extend aggregation tests to cover typical, single-value, and non-numeric scenarios for stddev

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e1a24b56588330a3cc6ab62211ae05