### PR TITLE
Add drop(n) helper for skipping array elements

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.63  2025-10-06
+    [Feature]
+    - Added drop(n) helper to skip the first N elements of arrays.
+    - Documented the helper across README, POD, CLI help, and tests.
+
 0.62  2025-10-05
     [Feature]
     - Added stddev helper to calculate the standard deviation of numeric array
@@ -308,7 +313,6 @@
     - Removed use of eval in _evaluate_condition for better performance and stability.
     - Refactored _traverse for readability and maintainability.
     - Added support for multi-level array traversal (e.g., .users[].friends[].name).
-
 
 
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `last`         | Get the last element of an array                     |
 | `reverse`      | Reverse an array                                     |
 | `limit(n)`     | Limit array to first `n` elements                    |
+| `drop(n)`      | Skip the first `n` elements in an array              |
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `add`, `sum`, `min`, `max`, `avg`, `median`, `stddev`, `product` | Numeric aggregation functions            |
@@ -246,6 +247,7 @@ jq-lite '.users[] | select(.age > 25)' users.json
 jq-lite '.users[] | select(.profile.active == true) | .name' users.json
 jq-lite '.users | sort_by(.age)' users.json
 jq-lite '.users | map(.name) | join(", ")' users.json
+jq-lite '.users | drop(1)' users.json
 jq-lite '.users[] | select(.age > 25) | empty' users.json
 jq-lite '.users[0] | values' users.json
 jq-lite '.users[0].name | type' users.json

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -334,6 +334,7 @@ Supported Functions:
   reverse          - Reverse an array
   first / last     - Get first / last element of an array
   limit(N)         - Limit array to first N elements
+  drop(N)          - Skip the first N elements of an array
   count            - Count total number of matching items
   map(EXPR)        - Map/filter array items with a subquery
   add / sum        - Sum all numeric values in an array

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -6,7 +6,7 @@ use JSON::PP;
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 
-our $VERSION = '0.62';
+our $VERSION = '0.63';
 
 sub new {
     my ($class, %opts) = @_;
@@ -209,6 +209,25 @@ sub run_query {
                     [ @$arr[0 .. $end] ]
                 } else {
                     $_
+                }
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for drop(n)
+        if ($part =~ /^drop\((\d+)\)$/) {
+            my $count = $1;
+            @next_results = map {
+                if (ref $_ eq 'ARRAY') {
+                    my $arr = $_;
+                    if ($count >= @$arr) {
+                        [];
+                    } else {
+                        [ @$arr[$count .. $#$arr] ];
+                    }
+                } else {
+                    $_;
                 }
             } @results;
             @results = @next_results;
@@ -1287,9 +1306,9 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_desc, sort_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, product, min, max, avg, median, stddev
+=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_desc, sort_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, product, min, max, avg, median, stddev, drop
 
-=item * Supports map(...) and limit(n) style transformations
+=item * Supports map(...), limit(n), and drop(n) style transformations
 
 =item * Interactive mode for exploring queries line-by-line
 

--- a/t/drop.t
+++ b/t/drop.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "numbers": [1, 2, 3, 4],
+  "user": { "name": "Alice" }
+});
+
+my $jq = JQ::Lite->new;
+
+my @drop_0 = $jq->run_query($json, '.numbers | drop(0)');
+my @drop_2 = $jq->run_query($json, '.numbers | drop(2)');
+my @drop_5 = $jq->run_query($json, '.numbers | drop(5)');
+my @non_array = $jq->run_query($json, '.user | drop(1)');
+
+is_deeply($drop_0[0], [1, 2, 3, 4], 'drop(0) keeps all elements');
+is_deeply($drop_2[0], [3, 4], 'drop(2) skips the first two elements');
+is_deeply($drop_5[0], [], 'drop(5) returns an empty array when count exceeds length');
+is_deeply($non_array[0], { name => 'Alice' }, 'drop(n) leaves non-array values unchanged');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a `drop(n)` helper to omit the first N elements from array results
- document the new helper across the README, POD, change log, and CLI help output
- add targeted regression tests covering array and non-array inputs

## Testing
- prove -l t

------
https://chatgpt.com/codex/tasks/task_e_68e1a5178a0483308d89c49442f90a09