### PR TITLE
Add chunks() helper for splitting arrays into fixed-size groups

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.64  2025-10-07
+    [Feature]
+    - Added chunks(n) helper to split arrays into evenly-sized subarrays.
+    - Documented the helper across README, POD, CLI help, and tests.
+
 0.63  2025-10-06
     [Feature]
     - Added drop(n) helper to skip the first N elements of arrays.

--- a/MANIFEST
+++ b/MANIFEST
@@ -13,6 +13,7 @@ t/contains.t
 t/contains_function.t
 t/case_transform.t
 t/ceil_floor.t
+t/chunks.t
 t/count.t
 t/empty.t
 t/first_last.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -56,6 +56,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `reverse`      | Reverse an array                                     |
 | `limit(n)`     | Limit array to first `n` elements                    |
 | `drop(n)`      | Skip the first `n` elements in an array              |
+| `chunks(n)`    | Split an array into subarrays with `n` items each (v0.64) |
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `add`, `sum`, `min`, `max`, `avg`, `median`, `stddev`, `product` | Numeric aggregation functions            |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -335,6 +335,7 @@ Supported Functions:
   first / last     - Get first / last element of an array
   limit(N)         - Limit array to first N elements
   drop(N)          - Skip the first N elements of an array
+  chunks(N)        - Split array into subarrays each containing up to N items
   count            - Count total number of matching items
   map(EXPR)        - Map/filter array items with a subquery
   add / sum        - Sum all numeric values in an array

--- a/t/chunks.t
+++ b/t/chunks.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+
+use Test::More;
+use JQ::Lite;
+use JSON::PP;
+
+my $jq = JQ::Lite->new;
+
+my $json = encode_json({ numbers => [1, 2, 3, 4, 5] });
+my $decoded = decode_json($json);
+my @result = $jq->run_query($json, '.numbers | chunks(2)');
+my $expected = [ [1, 2], [3, 4], [5] ];
+is_deeply($result[0], $expected, 'chunks(2) splits array into pairs');
+
+@result = $jq->run_query($json, '.numbers | chunks(3) | map(length)');
+$expected = [3, 2];
+is_deeply($result[0], $expected, 'chunks(3) works with map pipeline');
+
+my $empty_json = encode_json({ items => [] });
+@result = $jq->run_query($empty_json, '.items | chunks(4)');
+$expected = [];
+is_deeply($result[0], $expected, 'chunks handles empty arrays');
+
+@result = $jq->run_query($json, '.numbers | chunks(0)');
+$expected = [ [1], [2], [3], [4], [5] ];
+is_deeply($result[0], $expected, 'chunks(0) falls back to size 1');
+
+@result = $jq->run_query($json, 'chunks(2)');
+is_deeply($result[0], $decoded, 'chunks leaves non-array values unchanged');
+
+
+done_testing();


### PR DESCRIPTION
## Summary
- add a new chunks(n) pipeline helper that groups array results into equally sized subarrays inside `JQ::Lite`
- document the new helper across the README, module POD, CLI `--help-functions`, and changelog
- cover the behaviour with regression tests, including empty arrays, pipelines, and fallback handling

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e1a72dbecc8330b94d5467d699822a