### PR TITLE
Add flatten_deep helper for recursive array flattening

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.65  2025-10-05
+    [Feature]
+    - Added flatten_deep helper to recursively flatten nested arrays into a single list.
+    - Documented the helper across README, POD, CLI help, and tests.
+
 0.64  2025-10-05
     [Feature]
     - Added chunks(n) helper to split arrays into evenly-sized subarrays.

--- a/MANIFEST
+++ b/MANIFEST
@@ -18,6 +18,7 @@ t/count.t
 t/empty.t
 t/first_last.t
 t/flatten.t
+t/flatten_deep.t
 t/friends.t
 t/group_by.t
 t/group_count.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_deep()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -77,6 +77,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `join(sep)`    | Join array elements with custom separator (v0.31+)   |
 | `empty()`      | Discard all results (compatible with jq) (v0.33+)    |
 | `flatten()`    | Flatten array one level deep (like `.[]`) (v0.35)    |
+| `flatten_deep()` | Recursively flatten nested arrays into a single list (v0.65) |
 | `type()`       | Return the type of the value ("string", "number", "boolean", "array", "object", "null") (v0.36) |
 | `nth(n)`       | Get the nth element of an array (v0.37)              |
 | `del(key)`     | Delete a specified key from a hash object (v0.38)    |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -359,6 +359,7 @@ Supported Functions:
   contains         - Check if strings include a fragment, arrays contain an element, or hashes have a key
   match("pattern") - Match string using regex
   flatten          - Explicitly flatten arrays (same as .[])
+  flatten_deep     - Recursively flatten nested arrays into a single list
   del(KEY)         - Remove a key from objects in the result
   compact          - Remove undefined values from arrays
   path             - Return available keys for objects or indexes for arrays

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -51,6 +51,20 @@ sub run_query {
             next;
         }
 
+        # support for flatten_deep (recursive flatten)
+        if ($part eq 'flatten_deep') {
+            @next_results = map {
+                if (ref $_ eq 'ARRAY') {
+                    [ _flatten_deep($_) ];
+                }
+                else {
+                    $_;
+                }
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
         # support for select(...)
         if ($part =~ /^select\((.+)\)$/) {
             my $cond = $1;
@@ -1190,6 +1204,23 @@ sub _parse_arguments {
     return map { s/^\s+|\s+$//gr } @parts;
 }
 
+sub _flatten_deep {
+    my ($value) = @_;
+
+    return () unless ref $value eq 'ARRAY';
+
+    my @flat;
+    for my $item (@$value) {
+        if (ref $item eq 'ARRAY') {
+            push @flat, _flatten_deep($item);
+        } else {
+            push @flat, $item;
+        }
+    }
+
+    return @flat;
+}
+
 sub _apply_contains {
     my ($value, $needle) = @_;
 
@@ -1334,7 +1365,7 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_desc, sort_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, product, min, max, avg, median, stddev, drop, chunks
+=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_desc, sort_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, abs, ceil, floor, trim, substr, startswith, endswith, add, sum, product, min, max, avg, median, stddev, drop, chunks, flatten_deep
 
 =item * Supports map(...), limit(n), drop(n), and chunks(n) style transformations
 

--- a/t/flatten_deep.t
+++ b/t/flatten_deep.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = <<'JSON';
+{
+  "items": [
+    1,
+    [2, [3, 4], []],
+    [[5], [[6, 7]]],
+    [{"foo": "bar"}],
+    null
+  ],
+  "value": 42
+}
+JSON
+
+my $jq = JQ::Lite->new;
+my @results = $jq->run_query($json, '.items | flatten_deep');
+
+is(scalar @results, 1, 'flatten_deep returns a single flattened array');
+
+is_deeply(
+    $results[0],
+    [1, 2, 3, 4, 5, 6, 7, { foo => 'bar' }, undef],
+    'flatten_deep recursively flattens nested arrays and preserves other values',
+);
+
+my @scalar = $jq->run_query($json, '.value | flatten_deep');
+
+is_deeply(\@scalar, [42], 'flatten_deep leaves non-array values unchanged');
+
+done_testing();


### PR DESCRIPTION
## Summary
- add a `flatten_deep` helper that recursively flattens nested arrays and integrates with JQ::Lite queries
- document the new helper across the README, CLI help text, POD, and manifest entries
- cover the behaviour with dedicated regression tests and update the changelog

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e1a8af77308330ac48384492d7ee50