### PR TITLE
Add index(value) helper for arrays and strings

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.65  2025-10-05
+    [Feature]
+    - Added index(value) helper to return the first matching index for arrays or
+      substring position for scalars.
+    - Documented the helper across README, POD, CLI help, and tests.
+
 0.64  2025-10-05
     [Feature]
     - Added chunks(n) helper to split arrays into evenly-sized subarrays.

--- a/MANIFEST
+++ b/MANIFEST
@@ -22,6 +22,7 @@ t/friends.t
 t/group_by.t
 t/group_count.t
 t/has.t
+t/index.t
 t/join.t
 t/limit.t
 t/length.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `index()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -79,6 +79,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `flatten()`    | Flatten array one level deep (like `.[]`) (v0.35)    |
 | `type()`       | Return the type of the value ("string", "number", "boolean", "array", "object", "null") (v0.36) |
 | `nth(n)`       | Get the nth element of an array (v0.37)              |
+| `index(value)` | Return the zero-based index of the first match in arrays or strings (v0.65) |
 | `del(key)`     | Delete a specified key from a hash object (v0.38)    |
 | `compact()`    | Remove undef/null values from arrays (v0.39)         |
 | `upper()`      | Convert scalars (and array elements) to uppercase (v0.47) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -349,6 +349,7 @@ Supported Functions:
   floor()          - Round numbers down to the nearest integer
   round()          - Round numbers to the nearest integer (half-up semantics)
   nth(N)           - Get the Nth element of an array (zero-based index)
+  index(VALUE)     - Return the zero-based index of VALUE within arrays or strings
   group_by(KEY)    - Group array items by field
   group_count(KEY) - Count grouped items by field
   join(SEPARATOR)  - Join array elements with a string

--- a/t/index.t
+++ b/t/index.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "users": [
+    {"name": "Alice", "age": 30},
+    {"name": "Bob", "age": 25},
+    {"name": "Carol", "age": 35}
+  ],
+  "tags": ["perl", "json", "cli"],
+  "title": "jq-lite in perl",
+  "flags": [true, false, true]
+});
+
+my $jq = JQ::Lite->new;
+
+my @object_index = $jq->run_query($json, '.users | index({"name":"Bob","age":25})');
+is(scalar @object_index, 1, 'object index returns single result');
+is($object_index[0], 1, 'object index finds the first matching entry');
+
+my @array_index = $jq->run_query($json, '.tags | index("perl")');
+is($array_index[0], 0, 'scalar array search returns zero-based index');
+
+my @string_index = $jq->run_query($json, '.title | index("lite")');
+is($string_index[0], 3, 'substring search returns the expected offset');
+
+my @boolean_index = $jq->run_query($json, '.flags | index(true)');
+is($boolean_index[0], 0, 'boolean search matches JSON::PP::Boolean values');
+
+my @missing = $jq->run_query($json, '.tags | index("python")');
+ok(!defined $missing[0], 'missing values yield undef (null)');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add an index(value) helper that returns the first matching index for arrays and substring offsets for scalars
- document the new helper across the README, module POD, CLI help, and change log
- cover the feature with regression tests for arrays, strings, booleans, and missing results

## Testing
- prove -l t

------
https://chatgpt.com/codex/tasks/task_e_68e1a8af77308330ac48384492d7ee50