### PR TITLE
Add slice helper for array subranges

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.66  2025-10-05
+    [Feature]
+    - Added slice(start[, length]) helper to extract portions of arrays using
+      zero-based indices (including support for negative starts).
+    - Documented the helper across README, POD, CLI help, and tests.
+
 0.65  2025-10-05
     [Feature]
     - Added index(value) helper to return the first matching index for arrays or

--- a/MANIFEST
+++ b/MANIFEST
@@ -37,6 +37,7 @@ t/replace.t
 t/round.t
 t/sort_desc.t
 t/split.t
+t/slice.t
 t/sort_by.t
 t/sort_unique.t
 t/substr.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `index()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `index()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -70,6 +70,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `split(separator)` | Split a string (or array of strings) using a literal separator (v0.52) |
 | `replace(old, new)` | Replace all occurrences of a literal substring with another value (arrays processed element-wise) (unreleased) |
 | `substr(start, length)` | Extract a substring using zero-based indexing (arrays are processed element-wise) (v0.57) |
+| `slice(start, length)` | Return a subarray using zero-based indexing with optional length (negative starts count from the end) (v0.66) |
 | `contains(value)` | Check whether strings include the value or arrays contain an element (v0.56) |
 | `group_by(key)`| Group array items by field                           |
 | `group_count(key)` | Count how many items fall under each key (v0.46)   |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -356,6 +356,8 @@ Supported Functions:
   split(SEPARATOR) - Split string values (and arrays of strings) by a literal separator
   substr(START[, LENGTH])
                    - Extract substring using zero-based indices (arrays handled element-wise)
+  slice(START[, LENGTH])
+                  - Return a subarray using zero-based indices (negative starts count from the end)
   has              - Check if object has a given key
   contains         - Check if strings include a fragment, arrays contain an element, or hashes have a key
   match("pattern") - Match string using regex

--- a/t/slice.t
+++ b/t/slice.t
@@ -1,0 +1,35 @@
+use strict;
+use warnings;
+
+use Test::More;
+use JQ::Lite;
+use JSON::PP;
+
+my $jq = JQ::Lite->new;
+
+my $json = encode_json({ numbers => [10, 20, 30, 40, 50] });
+
+my @result = $jq->run_query($json, '.numbers | slice(1, 2)');
+is_deeply($result[0], [20, 30], 'slice(1, 2) returns middle segment');
+
+@result = $jq->run_query($json, '.numbers | slice(3)');
+is_deeply($result[0], [40, 50], 'slice(3) defaults length to array end');
+
+@result = $jq->run_query($json, '.numbers | slice(-2, 1)');
+is_deeply($result[0], [40], 'slice(-2, 1) supports negative start offsets');
+
+@result = $jq->run_query($json, '.numbers | slice(10)');
+is_deeply($result[0], [], 'slice start beyond array produces empty array');
+
+@result = $jq->run_query($json, '.numbers | slice(-10, 2)');
+is_deeply($result[0], [10, 20], 'slice clamps negative starts earlier than array length');
+
+@result = $jq->run_query($json, '.numbers | slice(2, 0)');
+is_deeply($result[0], [], 'slice with non-positive length is empty');
+
+my $json_scalar = encode_json({ value => 42 });
+@result = $jq->run_query($json_scalar, '.value | slice(1, 2)');
+is($result[0], 42, 'slice leaves scalar values unchanged');
+
+
+done_testing();


### PR DESCRIPTION
## Summary
- add a slice(start[, length]) pipeline helper to extract subranges from arrays, including support for negative offsets
- document the new helper throughout the README, module POD, CLI help, and change log
- add dedicated regression tests and include them in the MANIFEST

## Testing
- prove -l t/slice.t
- prove -l t

------
https://chatgpt.com/codex/tasks/task_e_68e1aadd99a8833088c9c6021574f58e