### PR TITLE
Add sum_by helper for aggregating projected numeric values

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+0.68  2025-10-05
+    [Feature]
+    - Added sum_by(path) helper to aggregate numeric values from array items.
+    - Documented the helper across README, POD, CLI help, and tests.
+
 0.67  2025-10-05
     [Feature]
     - Added flatten_all() helper to recursively flatten nested arrays.

--- a/MANIFEST
+++ b/MANIFEST
@@ -41,6 +41,7 @@ t/split.t
 t/slice.t
 t/sort_by.t
 t/sort_unique.t
+t/sum_by.t
 t/substr.t
 t/startswith_endswith.t
 t/unique_by.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `index()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `index()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -59,7 +59,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `chunks(n)`    | Split an array into subarrays with `n` items each (v0.64) |
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
-| `add`, `sum`, `min`, `max`, `avg`, `median`, `stddev`, `product` | Numeric aggregation functions            |
+| `add`, `sum`, `sum_by(path)`, `min`, `max`, `avg`, `median`, `stddev`, `product` | Numeric aggregation functions            |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
 | `ceil`        | Round numbers up to the nearest integer (v0.53)        |
 | `floor`       | Round numbers down to the nearest integer (v0.53)      |
@@ -74,6 +74,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `contains(value)` | Check whether strings include the value or arrays contain an element (v0.56) |
 | `group_by(key)`| Group array items by field                           |
 | `group_count(key)` | Count how many items fall under each key (v0.46)   |
+| `sum_by(path)` | Sum numeric values projected from each array item (v0.68) |
 | `count`        | Count total number of matching items                 |
 | `join(sep)`    | Join array elements with custom separator (v0.31+)   |
 | `empty()`      | Discard all results (compatible with jq) (v0.33+)    |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -339,6 +339,7 @@ Supported Functions:
   count            - Count total number of matching items
   map(EXPR)        - Map/filter array items with a subquery
   add / sum        - Sum all numeric values in an array
+  sum_by(KEY)      - Sum numeric values projected from each array item
   product          - Multiply all numeric values in an array
   min / max        - Return minimum / maximum numeric value in an array
   avg              - Return the average of numeric values in an array

--- a/t/sum_by.t
+++ b/t/sum_by.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my $objects = q([
+  { "amount": 10 },
+  { "amount": 25 },
+  { "amount": 5 }
+]);
+
+my ($sum_amount) = $jq->run_query($objects, 'sum_by(.amount)');
+is($sum_amount, 40, 'sum_by(.amount) sums numeric fields across objects');
+
+my $mixed = q([
+  { "amount": 5 },
+  { "amount": null },
+  { "amount": "ignore" },
+  { "amount": 10 }
+]);
+
+my ($sum_mixed) = $jq->run_query($mixed, 'sum_by(.amount)');
+is($sum_mixed, 15, 'sum_by(.amount) ignores non-numeric values');
+
+my $numbers = q([1, 2, 3, 4]);
+my ($sum_direct) = $jq->run_query($numbers, 'sum_by(.)');
+is($sum_direct, 10, 'sum_by(.) sums numeric array items directly');
+
+my $nested = q([
+  { "meta": { "scores": [1, 2] } },
+  { "meta": { "scores": [3] } }
+]);
+
+my ($sum_nested) = $jq->run_query($nested, 'sum_by(.meta.scores[])');
+is($sum_nested, 6, 'sum_by handles traversal paths yielding multiple values');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a `sum_by(path)` helper that aggregates numeric values projected from array items
- document the new helper across the README, CLI help, POD, and change log
- add regression tests covering direct, mixed, and nested sum_by usage

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e1af79720483309dc85bbe98a398aa