### PR TITLE
Add flatten_depth helper for controlled array flattening

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.70  2025-10-05
+    [Feature]
+    - Added flatten_depth(n) helper to flatten nested arrays up to a specified
+      depth while preserving deeper structure.
+    - Documented the helper across README, POD, CLI help, and regression tests.
+
 0.69  2025-10-05
     [Feature]
     - Added titlecase() helper to convert scalars and arrays to title case.

--- a/MANIFEST
+++ b/MANIFEST
@@ -19,6 +19,7 @@ t/empty.t
 t/first_last.t
 t/flatten.t
 t/flatten_all.t
+t/flatten_depth.t
 t/friends.t
 t/group_by.t
 t/group_count.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `index()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `flatten_depth()`, `index()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -80,6 +80,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `empty()`      | Discard all results (compatible with jq) (v0.33+)    |
 | `flatten()`    | Flatten array one level deep (like `.[]`) (v0.35)    |
 | `flatten_all()`| Recursively flatten nested arrays into a single array (v0.67) |
+| `flatten_depth(n)` | Flatten nested arrays up to `n` levels deep (v0.70) |
 | `type()`       | Return the type of the value ("string", "number", "boolean", "array", "object", "null") (v0.36) |
 | `nth(n)`       | Get the nth element of an array (v0.37)              |
 | `index(value)` | Return the zero-based index of the first match in arrays or strings (v0.65) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -364,6 +364,7 @@ Supported Functions:
   match("pattern") - Match string using regex
   flatten          - Explicitly flatten arrays (same as .[])
   flatten_all()    - Recursively flatten nested arrays into a single array
+  flatten_depth(N) - Flatten nested arrays up to N levels deep
   del(KEY)         - Remove a key from objects in the result
   compact          - Remove undefined values from arrays
   path             - Return available keys for objects or indexes for arrays

--- a/t/flatten_depth.t
+++ b/t/flatten_depth.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my $json_nested = <<'JSON';
+[[1, 2], [3, [4, 5]], 6]
+JSON
+
+my @depth_one = $jq->run_query($json_nested, 'flatten_depth(1)');
+is_deeply(
+    $depth_one[0],
+    [1, 2, 3, [4, 5], 6],
+    'flatten_depth(1) flattens one level of nesting'
+);
+
+my @depth_two = $jq->run_query($json_nested, 'flatten_depth(2)');
+is_deeply(
+    $depth_two[0],
+    [1, 2, 3, 4, 5, 6],
+    'flatten_depth(2) flattens two levels of nesting'
+);
+
+my @depth_zero = $jq->run_query($json_nested, 'flatten_depth(0)');
+is_deeply(
+    $depth_zero[0],
+    [ [1, 2], [3, [4, 5]], 6 ],
+    'flatten_depth(0) leaves the structure unchanged'
+);
+
+my @default_depth = $jq->run_query($json_nested, 'flatten_depth');
+is_deeply(
+    $default_depth[0],
+    [1, 2, 3, [4, 5], 6],
+    'flatten_depth defaults to a depth of 1 when omitted'
+);
+
+my $json_mixed = <<'JSON';
+[[{"name":"Alice"}], [{"name":"Bob", "pets":["cat", "dog"]}]]
+JSON
+
+my @mixed = $jq->run_query($json_mixed, 'flatten_depth(1)');
+is_deeply(
+    $mixed[0],
+    [
+        { name => 'Alice' },
+        { name => 'Bob', pets => ['cat', 'dog'] },
+    ],
+    'flatten_depth preserves non-array elements while flattening arrays'
+);
+
+my @non_array = $jq->run_query('"scalar"', 'flatten_depth(3)');
+is($non_array[0], 'scalar', 'flatten_depth leaves non-arrays untouched');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a flatten_depth helper and query support so arrays can be flattened to a configurable depth
- document the new helper across the README, module POD, CLI help, and change log entries
- cover the behaviour with new regression tests for multiple depth values and edge cases

## Testing
- prove -l t/flatten_depth.t
- prove -l t


------
https://chatgpt.com/codex/tasks/task_e_68e1b8e09be0833097cdaef3344fdb67