### PR TITLE
Add to_number() helper for numeric coercion

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.72  2025-10-05
+    [Feature]
+    - Added to_number() helper to coerce numeric-looking strings and booleans
+      into Perl numbers while preserving non-numeric values.
+    - Documented the helper across README, POD, CLI help, and regression tests.
+
 0.71  2025-10-05
     [Feature]
     - Added has(key) helper to verify object keys and array indexes.

--- a/MANIFEST
+++ b/MANIFEST
@@ -46,6 +46,7 @@ t/sort_unique.t
 t/sum_by.t
 t/substr.t
 t/startswith_endswith.t
+t/to_number.t
 t/unique_by.t
 t/trim.t
 t/values.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `flatten_depth()`, `index()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `flatten_depth()`, `index()`, `to_number()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -64,6 +64,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `ceil`        | Round numbers up to the nearest integer (v0.53)        |
 | `floor`       | Round numbers down to the nearest integer (v0.53)      |
 | `round`       | Round numbers to the nearest integer (v0.54)           |
+| `to_number`   | Convert numeric-looking strings/booleans to numbers (v0.72) |
 | `trim`        | Remove leading/trailing whitespace from strings (v0.50) |
 | `startswith(prefix)` | Check if a string (or array of strings) begins with `prefix` (v0.51) |
 | `endswith(suffix)` | Check if a string (or array of strings) ends with `suffix` (v0.51) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -349,6 +349,7 @@ Supported Functions:
   ceil()           - Round numbers up to the nearest integer
   floor()          - Round numbers down to the nearest integer
   round()          - Round numbers to the nearest integer (half-up semantics)
+  to_number()      - Coerce numeric-looking strings/booleans into numbers
   nth(N)           - Get the Nth element of an array (zero-based index)
   index(VALUE)     - Return the zero-based index of VALUE within arrays or strings
   group_by(KEY)    - Group array items by field

--- a/t/to_number.t
+++ b/t/to_number.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "score": "42",
+  "raw": "n/a",
+  "flag": true,
+  "nested": [["10", "oops"], [false, "0"]],
+  "maybe": null
+});
+
+my $jq = JQ::Lite->new;
+
+my @scalar = $jq->run_query($json, '.score | to_number');
+is($scalar[0], 42, 'to_number converts numeric strings to numbers');
+ok(!ref $scalar[0], 'to_number returns plain scalars for converted values');
+
+my @boolean = $jq->run_query($json, '.flag | to_number');
+is($boolean[0], 1, 'to_number converts JSON booleans to numeric values');
+
+my @string = $jq->run_query($json, '.raw | to_number');
+is($string[0], 'n/a', 'non-numeric strings remain unchanged');
+
+my @array = $jq->run_query($json, '.nested | to_number');
+is_deeply(
+    $array[0],
+    [[10, 'oops'], [0, 0]],
+    'to_number recurses through arrays preserving non-numeric entries'
+);
+
+my @maybe = $jq->run_query($json, '.maybe | to_number');
+ok(!defined $maybe[0], 'undef/null input stays undef after to_number');
+
+my @missing = $jq->run_query($json, '.missing? | to_number');
+ok(!defined $missing[0], 'optional keys remain undef when absent');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a `to_number()` helper that coerces numeric-looking strings and booleans during query execution
- document the new helper across the README, module POD, and CLI help output
- add regression coverage and manifest updates for the new function

## Testing
- prove -l t

------
https://chatgpt.com/codex/tasks/task_e_68e1bda13f1083309c9c51b17fc30709