### PR TITLE
Add min_by/max_by helpers for projected comparisons

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.75  2025-10-09
+    [Feature]
+    - Added min_by(path) and max_by(path) helpers to select array elements with
+      the smallest or largest projected value.
+    - Documented the helpers across README, POD, CLI help, and regression tests.
+
 0.74  2025-10-08
     [Feature]
     - Added pick(key1, key2, ...) helper to build objects that only include the

--- a/MANIFEST
+++ b/MANIFEST
@@ -32,6 +32,7 @@ t/limit.t
 t/length.t
 t/map.t
 t/median.t
+t/min_max_by.t
 t/match.t
 t/match_i.t
 t/pipe_select_name.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `flatten_depth()`, `index()`, `clamp()`, `to_number()`, `pick()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `flatten_depth()`, `index()`, `clamp()`, `to_number()`, `pick()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -49,6 +49,8 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `sort`         | Sort array items                                     |
 | `sort_desc`    | Sort array items in descending order (v0.61)         |
 | `sort_by(key)` | Sort array of objects by field (v0.32)               |
+| `min_by(path)` | Return the element with the smallest projected value (v0.75) |
+| `max_by(path)` | Return the element with the largest projected value (v0.75) |
 | `unique`       | Remove duplicate values                              |
 | `unique_by(path)` | Remove duplicates by projecting each entry to a key path (v0.60) |
 | `first`        | Get the first element of an array                    |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -341,6 +341,8 @@ Supported Functions:
   map(EXPR)        - Map/filter array items with a subquery
   add / sum        - Sum all numeric values in an array
   sum_by(KEY)      - Sum numeric values projected from each array item
+  min_by(PATH)     - Return the element with the smallest projected value
+  max_by(PATH)     - Return the element with the largest projected value
   product          - Multiply all numeric values in an array
   min / max        - Return minimum / maximum numeric value in an array
   avg              - Return the average of numeric values in an array

--- a/t/min_max_by.t
+++ b/t/min_max_by.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = <<'JSON';
+{
+  "users": [
+    { "name": "Alice", "age": 30 },
+    { "name": "Bob",   "age": 20 },
+    { "name": "Carol", "age": 25 }
+  ]
+}
+JSON
+
+my $jq = JQ::Lite->new;
+
+my @result = $jq->run_query($json, '.users | max_by(.age) | .name');
+is_deeply(
+    \@result,
+    ['Alice'],
+    'max_by(.age) returns user with the largest age',
+);
+
+@result = $jq->run_query($json, '.users | min_by(.age) | .name');
+is_deeply(
+    \@result,
+    ['Bob'],
+    'min_by(.age) returns user with the smallest age',
+);
+
+@result = $jq->run_query($json, '.users | max_by(.name) | .name');
+is_deeply(
+    \@result,
+    ['Carol'],
+    'max_by(.name) compares projected string values',
+);
+
+my $numbers = '[3, 10, 7, -2]';
+
+@result = $jq->run_query($numbers, '. | max_by(.)');
+is_deeply(
+    \@result,
+    [10],
+    'max_by(.) on scalars returns the largest numeric value',
+);
+
+@result = $jq->run_query($numbers, '. | min_by(.)');
+is_deeply(
+    \@result,
+    [-2],
+    'min_by(.) on scalars returns the smallest numeric value',
+);
+
+@result = $jq->run_query($json, '.users | min_by(.missing)');
+
+is(scalar @result, 1, 'min_by with missing path still returns a single result');
+ok(!defined $result[0], 'min_by(.missing) yields undef when no values are comparable');
+
+done_testing();


### PR DESCRIPTION
## Summary
- add `min_by(path)` and `max_by(path)` helpers to select array elements using projected values
- document the new functions across the README, CLI help, POD, and changelog
- cover the behaviour with regression tests and update the manifest

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e58597e76883309658c8c1c78867ad