### PR TITLE
Add mode aggregator to identify most frequent values

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.76  2025-10-10
+    [Feature]
+    - Added mode helper to return the most frequent array value with stable
+      tie-breaking based on first appearance.
+    - Documented the helper across README, POD, CLI help, and regression tests.
+
 0.75  2025-10-09
     [Feature]
     - Added min_by(path) and max_by(path) helpers to select array elements with

--- a/MANIFEST
+++ b/MANIFEST
@@ -32,6 +32,7 @@ t/limit.t
 t/length.t
 t/map.t
 t/median.t
+t/mode.t
 t/min_max_by.t
 t/match.t
 t/match_i.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `flatten_depth()`, `index()`, `clamp()`, `to_number()`, `pick()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `flatten_depth()`, `index()`, `clamp()`, `to_number()`, `pick()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -62,7 +62,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `pick(keys...)` | Build objects containing only the specified keys (v0.74) |
-| `add`, `sum`, `sum_by(path)`, `min`, `max`, `avg`, `median`, `stddev`, `product` | Numeric aggregation functions            |
+| `add`, `sum`, `sum_by(path)`, `min`, `max`, `avg`, `median`, `mode`, `stddev`, `product` | Numeric and statistical aggregation functions |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
 | `ceil`        | Round numbers up to the nearest integer (v0.53)        |
 | `floor`       | Round numbers down to the nearest integer (v0.53)      |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -347,6 +347,7 @@ Supported Functions:
   min / max        - Return minimum / maximum numeric value in an array
   avg              - Return the average of numeric values in an array
   median           - Return the median of numeric values in an array
+  mode             - Return the most frequent value in an array (ties pick earliest occurrence)
   stddev           - Return the standard deviation of numeric values in an array
   abs              - Convert numbers (and array elements) to their absolute value
   ceil()           - Round numbers up to the nearest integer

--- a/t/mode.t
+++ b/t/mode.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json_numbers = q([1, 2, 2, 3, 3, 3]);
+my $json_tie     = q(["apple", "banana", "apple", "banana"]);
+my $json_objects = q([
+  { "id": 1, "value": "x" },
+  { "id": 1, "value": "x" },
+  { "id": 2, "value": "y" }
+]);
+my $json_sparse = q([null, "keep", "keep", null]);
+my $json_empty  = q([]);
+
+my $jq = JQ::Lite->new;
+
+my ($mode_numbers) = $jq->run_query($json_numbers, 'mode');
+is($mode_numbers, 3, 'mode picks most frequent numeric value');
+
+my ($mode_tie) = $jq->run_query($json_tie, 'mode');
+is($mode_tie, 'apple', 'mode resolves ties using first occurrence');
+
+my ($mode_objects) = $jq->run_query($json_objects, 'mode | .id');
+is($mode_objects, 1, 'mode returns first matching object when structures repeat');
+
+my ($mode_sparse) = $jq->run_query($json_sparse, 'mode');
+is($mode_sparse, 'keep', 'mode skips undefined/null values');
+
+my ($mode_empty) = $jq->run_query($json_empty, 'mode');
+ok(!defined $mode_empty, 'mode returns undef for empty arrays');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a `mode` aggregation helper that returns the most frequent array value with stable tie-breaking
- document the new helper across the README, CLI help, POD, and bump the module version to 0.76
- add regression coverage for `mode` and list the new test in the MANIFEST

## Testing
- prove -l

------
https://chatgpt.com/codex/tasks/task_e_68e588be8a8c8330bca5de9032178eff