### PR TITLE
Add tail(n) helper for returning trailing array elements

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.79  2025-10-12
+    [Feature]
+    - Added tail(n) helper to return the last N elements from arrays while
+      preserving shorter inputs unchanged.
+    - Documented the helper across README, POD, CLI help, and regression tests.
+
 0.78  2025-10-11
     [Feature]
     - Added avg_by(path) helper to compute the arithmetic mean of numeric values

--- a/MANIFEST
+++ b/MANIFEST
@@ -49,6 +49,7 @@ t/slice.t
 t/sort_by.t
 t/sort_unique.t
 t/sum_by.t
+t/tail.t
 t/substr.t
 t/startswith_endswith.t
 t/to_number.t

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `reverse`      | Reverse an array                                     |
 | `limit(n)`     | Limit array to first `n` elements                    |
 | `drop(n)`      | Skip the first `n` elements in an array              |
+| `tail(n)`      | Return the final `n` elements in an array (v0.79)    |
 | `chunks(n)`    | Split an array into subarrays with `n` items each (v0.64) |
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -336,6 +336,7 @@ Supported Functions:
   first / last     - Get first / last element of an array
   limit(N)         - Limit array to first N elements
   drop(N)          - Skip the first N elements of an array
+  tail(N)          - Return the final N elements of an array
   chunks(N)        - Split array into subarrays each containing up to N items
   count            - Count total number of matching items
   map(EXPR)        - Map/filter array items with a subquery

--- a/t/tail.t
+++ b/t/tail.t
@@ -1,0 +1,31 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "users": [
+    { "name": "Alice" },
+    { "name": "Bob" },
+    { "name": "Carol" },
+    { "name": "Dave" }
+  ],
+  "status": "ok"
+});
+
+my $jq = JQ::Lite->new;
+
+my @tail_2 = $jq->run_query($json, '.users | tail(2)');
+my @tail_0 = $jq->run_query($json, '.users | tail(0)');
+my @tail_10 = $jq->run_query($json, '.users | tail(10)');
+my @tail_scalar = $jq->run_query($json, '.status | tail(3)');
+
+is_deeply($tail_2[0], [ { name => 'Carol' }, { name => 'Dave' } ], 'tail(2) returns final 2 elements');
+is_deeply($tail_0[0], [], 'tail(0) returns empty array');
+is_deeply([ map { $_->{name} } @{ $tail_10[0] } ],
+          [ 'Alice', 'Bob', 'Carol', 'Dave' ],
+          'tail(10) returns all elements when count exceeds length');
+
+is($tail_scalar[0], 'ok', 'tail on scalar passes value through unchanged');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a tail(n) helper that returns the trailing elements from array results
- document the new helper across README, POD, CLI help, and the changelog
- cover the behaviour with a dedicated regression test

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e9a5c96f04833080110b17f68f6ae5