### PR TITLE
Add merge_objects helper to JQ::Lite

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.80  2025-10-12
+    [Feature]
+    - Added merge_objects() helper to flatten arrays of hashes into a single
+      object using last-write-wins semantics while ignoring non-object entries.
+    - Documented the helper across README, POD, CLI help, and regression tests.
+
 0.79  2025-10-11
     [Feature]
     - Added tail(n) helper to return the last N elements from arrays while

--- a/MANIFEST
+++ b/MANIFEST
@@ -32,6 +32,7 @@ t/join.t
 t/limit.t
 t/length.t
 t/map.t
+t/merge_objects.t
 t/median.t
 t/mode.t
 t/min_max_by.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `flatten_depth()`, `index()`, `clamp()`, `to_number()`, `pick()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `flatten_all()`, `flatten_depth()`, `index()`, `clamp()`, `to_number()`, `pick()`, `merge_objects()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -63,6 +63,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `pick(keys...)` | Build objects containing only the specified keys (v0.74) |
+| `merge_objects()` | Shallow-merge arrays of objects into a single hash with last-write-wins semantics (v0.80) |
 | `add`, `sum`, `sum_by(path)`, `avg_by(path)`, `min`, `max`, `avg`, `median`, `mode`, `variance`, `stddev`, `product` | Numeric and statistical aggregation functions |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
 | `ceil`        | Round numbers up to the nearest integer (v0.53)        |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -330,6 +330,7 @@ Supported Functions:
   sort_by(KEY)     - Sort array of objects by key
   pluck(KEY)       - Collect a key's value from each object in an array
   pick(KEYS...)    - Build new objects containing only the supplied keys (arrays handled element-wise)
+  merge_objects()  - Merge arrays of objects into a single hash (last-write-wins)
   unique           - Remove duplicate values
   unique_by(KEY)   - Remove duplicates by projecting each item on KEY
   reverse          - Reverse an array

--- a/t/merge_objects.t
+++ b/t/merge_objects.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use Test::More;
+use JSON::PP;
+use JQ::Lite;
+
+my $json = <<'JSON';
+{
+  "items": [
+    { "name": "Widget", "value": 1 },
+    { "value": 2, "active": true },
+    { "nested": { "id": 42 } },
+    7,
+    null,
+    ["ignored"]
+  ],
+  "single": { "foo": "bar" },
+  "no_hashes": ["alpha", "beta"]
+}
+JSON
+
+my $jq = JQ::Lite->new;
+
+my @merged = $jq->run_query($json, '.items | merge_objects');
+is_deeply(
+    \@merged,
+    [
+        {
+            name   => 'Widget',
+            value  => 2,
+            active => JSON::PP::true,
+            nested => { id => 42 },
+        }
+    ],
+    'merge_objects folds arrays of objects into one hash with later values winning',
+);
+
+my @single = $jq->run_query($json, '.single | merge_objects');
+is_deeply(
+    \@single,
+    [
+        { foo => 'bar' },
+    ],
+    'merge_objects returns a shallow copy when applied to a single object',
+);
+
+my @empty = $jq->run_query($json, '.no_hashes | merge_objects');
+is_deeply(
+    \@empty,
+    [
+        {},
+    ],
+    'merge_objects returns an empty hash when no objects are present in the array',
+);
+
+done_testing();


### PR DESCRIPTION
## Summary
- add a merge_objects() pipeline helper that collapses arrays of hashes into a single object with last-write-wins semantics
- document the new helper across README, POD, CLI help, and the changelog/manifest
- add regression coverage for array, single-object, and non-object inputs

## Testing
- prove -l

------
https://chatgpt.com/codex/tasks/task_e_68e9a76d0db08330af4c6b0f68a41e03