### PR TITLE
Add entry transformation helpers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.84  2025-10-12
+    [Feature]
+    - Added to_entries(), from_entries(), and with_entries(filter) helpers to
+      round out jq's entry transformation workflow for objects and arrays.
+    - Documented the helpers across README, POD, CLI help, and regression tests.
+
 0.83  2025-10-11
     [Feature]
     - Added median_by(path) helper to compute the median of numeric values

--- a/MANIFEST
+++ b/MANIFEST
@@ -18,6 +18,7 @@ t/ceil_floor.t
 t/chunks.t
 t/count.t
 t/empty.t
+t/entries.t
 t/enumerate.t
 t/first_last.t
 t/flatten.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `index()`, `clamp()`, `to_number()`, `pick()`, `merge_objects()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `index()`, `clamp()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -66,6 +66,9 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `pick(keys...)` | Build objects containing only the specified keys (v0.74) |
 | `merge_objects()` | Shallow-merge arrays of objects into a single hash with last-write-wins semantics (v0.80) |
+| `to_entries()` | Convert objects/arrays into an array of `{key, value}` pairs (v0.84) |
+| `from_entries()` | Convert entry arrays back into an object (v0.84) |
+| `with_entries(filter)` | Apply a filter to each entry before rebuilding the object (v0.84) |
 | `add`, `sum`, `sum_by(path)`, `avg_by(path)`, `median_by(path)`, `min`, `max`, `avg`, `median`, `mode`, `percentile(p)`, `variance`, `stddev`, `product` | Numeric and statistical aggregation functions |
 | `abs`         | Convert numeric values to their absolute value (v0.49) |
 | `ceil`        | Round numbers up to the nearest integer (v0.53)        |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -372,6 +372,10 @@ Supported Functions:
                    - Extract substring using zero-based indices (arrays handled element-wise)
   slice(START[, LENGTH])
                   - Return a subarray using zero-based indices (negative starts count from the end)
+  to_entries       - Convert objects/arrays into [{"key","value"}, ...] pairs
+  from_entries     - Convert entry arrays back into an object
+  with_entries(FILTER)
+                   - Transform entries using FILTER and rebuild an object
   has              - Check if objects contain a key or arrays expose an index
   contains         - Check if strings include a fragment, arrays contain an element, or hashes have a key
   match("pattern") - Match string using regex

--- a/t/entries.t
+++ b/t/entries.t
@@ -1,0 +1,65 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my $json = q({
+  "profile": {
+    "name": "Alice",
+    "age": 30
+  },
+  "tags": ["perl", "json"]
+});
+
+my @profile_entries = $jq->run_query($json, '.profile | to_entries');
+is_deeply(
+    $profile_entries[0],
+    [
+        { key => 'age',  value => 30 },
+        { key => 'name', value => 'Alice' },
+    ],
+    'to_entries converts objects into key/value pairs'
+);
+
+my @tag_entries = $jq->run_query($json, '.tags | to_entries');
+is_deeply(
+    $tag_entries[0],
+    [
+        { key => 0, value => 'perl' },
+        { key => 1, value => 'json' },
+    ],
+    'to_entries converts arrays using zero-based indexes'
+);
+
+my $entry_json = q([
+  {"key": "name", "value": "Alice"},
+  {"key": "role", "value": "admin"}
+]);
+my @from_entries = $jq->run_query($entry_json, 'from_entries');
+is_deeply(
+    $from_entries[0],
+    { name => 'Alice', role => 'admin' },
+    'from_entries rebuilds objects from entry hashes'
+);
+
+my $tuple_json = q([
+  ["lang", "perl"],
+  ["level", "pro"]
+]);
+my @from_tuple = $jq->run_query($tuple_json, 'from_entries');
+is_deeply(
+    $from_tuple[0],
+    { lang => 'perl', level => 'pro' },
+    'from_entries handles tuple-style entries'
+);
+
+my @filtered = $jq->run_query($json, '.profile | with_entries(select(.key != "age"))');
+is_deeply(
+    $filtered[0],
+    { name => 'Alice' },
+    'with_entries filters entries before reconstruction'
+);
+
+done_testing;


### PR DESCRIPTION
## Summary
- add jq-compatible to_entries, from_entries, and with_entries helpers to JQ::Lite
- update CLI help, README, and POD to document the new functions
- cover the entry helpers with regression tests and bump the module version

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68e9fc47740c83308004e3fe95f64aed