### PR TITLE
Add keys_unsorted helper for jq compatibility

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@
     - Added tostring() helper to convert values into their JSON string form,
       matching jq's behavior for scalars, booleans, null, arrays, and objects.
     - Documented the helper across README, POD, CLI help, and regression tests.
+    - Added keys_unsorted helper to expose jq's unsorted key traversal for
+      objects, along with documentation and regression tests.
 
 0.84  2025-10-11
     [Feature]

--- a/MANIFEST
+++ b/MANIFEST
@@ -31,6 +31,7 @@ t/has.t
 t/has_function.t
 t/index.t
 t/join.t
+t/keys_unsorted.t
 t/limit.t
 t/length.t
 t/map.t

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 |----------------|-------------------------------------------------------|
 | `length`       | Get number of elements in an array, keys in a hash, or characters in scalars |
 | `keys`         | Extract sorted keys from a hash                      |
+| `keys_unsorted` | Extract object keys without sorting (jq-compatible) |
 | `values`       | Extract values from a hash (v0.34)                   |
 | `sort`         | Sort array items                                     |
 | `sort_desc`    | Sort array items in descending order (v0.61)         |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -324,6 +324,7 @@ sub print_supported_functions {
 Supported Functions:
   length           - Count array elements, hash keys, or characters in scalars
   keys             - Extract sorted keys from a hash
+  keys_unsorted    - Extract object keys without sorting (jq-compatible)
   values           - Extract values from a hash (v0.34)
   sort             - Sort array items
   sort_desc        - Sort array items in descending order

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -91,6 +91,23 @@ sub run_query {
             next;
         }
 
+        # support for keys_unsorted
+        if ($part eq 'keys_unsorted' || $part eq 'keys_unsorted()') {
+            @next_results = map {
+                if (ref $_ eq 'HASH') {
+                    [ keys %$_ ];
+                }
+                elsif (ref $_ eq 'ARRAY') {
+                    [ 0 .. $#{$_} ];
+                }
+                else {
+                    undef;
+                }
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
         # support for sort
         if ($part eq 'sort') {
             @next_results = map {
@@ -2297,7 +2314,7 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, values, first, last, reverse, sort, sort_desc, sort_by, min_by, max_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, titlecase, abs, ceil, floor, trim, substr, slice, startswith, endswith, add, sum, sum_by, avg_by, median_by, product, min, max, avg, median, mode, percentile, variance, stddev, drop, tail, chunks, enumerate, transpose, flatten_all, flatten_depth, clamp, to_number, pick, merge_objects, to_entries, from_entries, with_entries
+=item * Built-in functions: length, keys, keys_unsorted, values, first, last, reverse, sort, sort_desc, sort_by, min_by, max_by, unique, unique_by, has, contains, group_by, group_count, join, split, count, empty, type, nth, del, compact, upper, lower, titlecase, abs, ceil, floor, trim, substr, slice, startswith, endswith, add, sum, sum_by, avg_by, median_by, product, min, max, avg, median, mode, percentile, variance, stddev, drop, tail, chunks, enumerate, transpose, flatten_all, flatten_depth, clamp, to_number, pick, merge_objects, to_entries, from_entries, with_entries
 
 =item * Supports map(...), limit(n), drop(n), tail(n), chunks(n), and enumerate() style transformations
 
@@ -2400,6 +2417,17 @@ Example:
 Results in:
 
   ["A", "l", "i", "c", "e"]
+
+
+=item * keys_unsorted()
+
+Returns the keys of an object without sorting them, mirroring jq's
+C<keys_unsorted> helper. Arrays yield their zero-based indices, while
+non-object/array inputs return C<undef> to match the behaviour of C<keys>.
+
+Example:
+
+  .profile | keys_unsorted
 
 =item * values()
 

--- a/t/keys_unsorted.t
+++ b/t/keys_unsorted.t
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+use Test::More;
+use JSON::PP;
+use JQ::Lite;
+
+my $json = <<'JSON';
+{
+  "object": {
+    "third": 3,
+    "first": 1,
+    "second": 2
+  },
+  "array": ["a", "b", "c"]
+}
+JSON
+
+my $jq = JQ::Lite->new;
+
+my @object = $jq->run_query($json, '.object | keys_unsorted');
+my @sorted = $jq->run_query($json, '.object | keys');
+
+is_deeply(
+    [ sort @{ $object[0] } ],
+    $sorted[0],
+    'keys_unsorted returns the same keys as keys when sorted',
+);
+
+isnt(
+    join(',', @{ $object[0] }),
+    join(',', @{ $sorted[0] }),
+    'keys_unsorted preserves unsorted ordering',
+);
+
+my @array = $jq->run_query($json, '.array | keys_unsorted');
+is_deeply($array[0], [0, 1, 2], 'keys_unsorted returns indexes for arrays');
+
+my @scalar = $jq->run_query($json, '.array[0] | keys_unsorted');
+ok(!defined $scalar[0], 'non-object/array inputs return undef');
+
+DONE_TESTING:
+done_testing();


### PR DESCRIPTION
## Summary
- add support for the jq-compatible `keys_unsorted` helper and keep array handling consistent
- document the new helper across README, CLI help, and module POD
- cover the helper with regression tests and manifest/update notes

## Testing
- `prove -lr t`


------
https://chatgpt.com/codex/tasks/task_e_68ea0c39bfb483309e97d363c80d05c0