### PR TITLE
Add ltrimstr and rtrimstr helpers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+0.87  2025-10-11
+    [Feature]
+    - Added ltrimstr(prefix) and rtrimstr(suffix) helpers to remove literal
+      prefixes/suffixes from strings while preserving non-matching values and
+      recursively processing arrays.
+    - Documented the helpers across README, POD, CLI help, and regression tests.
+
 0.86  2025-10-11
     [Feature]
     - Added range(start; end[, step]) helper to emit numeric sequences matching

--- a/MANIFEST
+++ b/MANIFEST
@@ -64,5 +64,6 @@ t/to_number.t
 t/tostring.t
 t/unique_by.t
 t/trim.t
+t/trimstr.t
 t/values.t
 LICENSE

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -80,6 +80,8 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `tostring`    | Convert values to their JSON string representation (v0.85) |
 | `to_number`   | Convert numeric-looking strings/booleans to numbers (v0.72) |
 | `trim`        | Remove leading/trailing whitespace from strings (v0.50) |
+| `ltrimstr(prefix)` | Remove `prefix` from the start of strings when present (v0.87) |
+| `rtrimstr(suffix)` | Remove `suffix` from the end of strings when present (v0.87) |
 | `startswith(prefix)` | Check if a string (or array of strings) begins with `prefix` (v0.51) |
 | `endswith(suffix)` | Check if a string (or array of strings) ends with `suffix` (v0.51) |
 | `split(separator)` | Split a string (or array of strings) using a literal separator (v0.52) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -394,6 +394,8 @@ Supported Functions:
   lower()          - Convert scalars and array elements to lowercase
   titlecase()      - Convert scalars and array elements to title case
   trim()           - Strip leading/trailing whitespace from strings (recurses into arrays)
+  ltrimstr(PFX)    - Remove PFX when it appears at the start of strings (arrays handled element-wise)
+  rtrimstr(SFX)    - Remove SFX when it appears at the end of strings (arrays handled element-wise)
   startswith(PFX)  - Check if a string (or array of strings) begins with PFX
   endswith(SFX)    - Check if a string (or array of strings) ends with SFX
   empty            - Discard all output (for side-effect use)

--- a/t/trimstr.t
+++ b/t/trimstr.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "value": "foobar",
+  "array": ["foobar", "barfoo", null, ["foo", "foobar"]],
+  "object": {"keep": "foobar"}
+});
+
+my $jq = JQ::Lite->new;
+
+my @left = $jq->run_query($json, '.value | ltrimstr("foo")');
+is($left[0], 'bar', 'ltrimstr removes matching prefix from scalar string');
+
+my @left_no_match = $jq->run_query($json, '.value | ltrimstr("bar")');
+is($left_no_match[0], 'foobar', 'ltrimstr leaves non-matching prefix untouched');
+
+my @right = $jq->run_query($json, '.value | rtrimstr("bar")');
+is($right[0], 'foo', 'rtrimstr removes matching suffix from scalar string');
+
+my @array_left = $jq->run_query($json, '.array | ltrimstr("foo")');
+is_deeply(
+    $array_left[0],
+    ['bar', 'barfoo', undef, ['', 'bar']],
+    'ltrimstr recurses into arrays and nested arrays'
+);
+
+my @array_right = $jq->run_query($json, '.array | rtrimstr("bar")');
+is_deeply(
+    $array_right[0],
+    ['foo', 'barfoo', undef, ['foo', 'foo']],
+    'rtrimstr recurses into arrays and nested arrays'
+);
+
+my @object = $jq->run_query($json, '.object | ltrimstr("foo")');
+is_deeply($object[0], { keep => 'foobar' }, 'ltrimstr leaves hashes untouched');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add jq-compatible ltrimstr(prefix) and rtrimstr(suffix) helpers with array-aware behavior
- document the new string helpers across README, module POD, CLI help, and Changes
- cover the new behavior with regression tests and add the test file to the manifest

## Testing
- prove -l

------
https://chatgpt.com/codex/tasks/task_e_68ea10f8c5708330af58710ae4f2a7aa