### PR TITLE
Add explode/implode helpers to match jq functionality

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+0.88  2025-10-11
+    [Feature]
+    - Added explode() and implode() helpers to convert between strings and
+      arrays of Unicode code points, mirroring jq's functions and handling
+      nested arrays element-wise.
+    - Documented the helpers across README, POD, and regression tests.
+
 0.87  2025-10-11
     [Feature]
     - Added ltrimstr(prefix) and rtrimstr(suffix) helpers to remove literal

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -85,6 +85,8 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `startswith(prefix)` | Check if a string (or array of strings) begins with `prefix` (v0.51) |
 | `endswith(suffix)` | Check if a string (or array of strings) ends with `suffix` (v0.51) |
 | `split(separator)` | Split a string (or array of strings) using a literal separator (v0.52) |
+| `explode()` | Convert strings into arrays of Unicode code points (v0.88) |
+| `implode()` | Turn arrays of code points back into strings (v0.88) |
 | `replace(old, new)` | Replace all occurrences of a literal substring with another value (arrays processed element-wise) (unreleased) |
 | `substr(start, length)` | Extract a substring using zero-based indexing (arrays are processed element-wise) (v0.57) |
 | `slice(start, length)` | Return a subarray using zero-based indexing with optional length (negative starts count from the end) (v0.66) |

--- a/t/explode_implode.t
+++ b/t/explode_implode.t
@@ -1,0 +1,46 @@
+use strict;
+use warnings;
+use Test::More;
+use JSON::PP ();
+use JQ::Lite;
+
+my $json = q({
+  "word": "Perl",
+  "words": ["Hi", "JSON", null, {"skip": true}],
+  "codes": [80, 101, 114, 108],
+  "nested": [[65, 66], [67, 68]],
+  "bool": true
+});
+
+my $jq = JQ::Lite->new;
+
+my @exploded = $jq->run_query($json, '.word | explode');
+is_deeply($exploded[0], [80, 101, 114, 108], 'explode converts string into Unicode code points');
+
+my @exploded_array = $jq->run_query($json, '.words | explode');
+my $expected_array = [
+    [72, 105],
+    [74, 83, 79, 78],
+    undef,
+    { skip => JSON::PP::true },
+];
+is_deeply($exploded_array[0], $expected_array, 'explode applies element-wise and preserves non-strings');
+
+my @bool_exploded = $jq->run_query($json, '.bool | explode');
+is_deeply($bool_exploded[0], [116, 114, 117, 101], 'explode stringifies booleans similar to jq');
+
+my @imploded = $jq->run_query($json, '.codes | implode');
+is($imploded[0], 'Perl', 'implode converts array of code points into string');
+
+my @roundtrip = $jq->run_query($json, '.nested | implode');
+my $expected_roundtrip = ['AB', 'CD'];
+is_deeply($roundtrip[0], $expected_roundtrip, 'implode maps nested arrays of code points back to strings');
+
+my @loop = $jq->run_query($json, '.word | explode | implode');
+is($loop[0], 'Perl', 'explode + implode roundtrip returns original string');
+
+my @mixed_implode = $jq->run_query($json, '.words | explode | implode');
+my $expected_mixed = ['Hi', 'JSON', undef, { skip => JSON::PP::true }];
+is_deeply($mixed_implode[0], $expected_mixed, 'implode reverses explode for arrays while leaving passthrough entries intact');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add explode() and implode() filters so jq-lite can convert between strings and code point arrays like jq
- document the new helpers and bump the distribution version to 0.88 in README, POD, and Changes
- add regression tests that cover explode/implode usage on scalars, arrays, and booleans

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68ea12d42398833098a24179f7b0c530