### PR TITLE
Add jq-compatible indices() helper

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+0.91  2025-10-11
+    [Feature]
+    - Added indices(value) helper to emit every index where the supplied value
+      occurs within arrays or strings, matching jq's behaviour for substring and
+      element searches. Documented the helper across README, POD, CLI help, and
+      regression tests.
+
 0.90  2025-10-11
     [Feature]
     - Added any([filter]) helper to mirror jq's any/0 and any/1 behaviour for

--- a/MANIFEST
+++ b/MANIFEST
@@ -31,6 +31,7 @@ t/group_count.t
 t/has.t
 t/has_function.t
 t/index.t
+t/indices.t
 t/join.t
 t/keys_unsorted.t
 t/limit.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -106,6 +106,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `type()`       | Return the type of the value ("string", "number", "boolean", "array", "object", "null") (v0.36) |
 | `nth(n)`       | Get the nth element of an array (v0.37)              |
 | `index(value)` | Return the zero-based index of the first match in arrays or strings (v0.65) |
+| `indices(value)` | Return every index where the value appears in arrays or strings (v0.91) |
 | `del(key)`     | Delete a specified key from a hash object (v0.38)    |
 | `compact()`    | Remove undef/null values from arrays (v0.39)         |
 | `upper()`      | Convert scalars (and array elements) to uppercase (v0.47) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -368,6 +368,7 @@ Supported Functions:
   to_number()      - Coerce numeric-looking strings/booleans into numbers
   nth(N)           - Get the Nth element of an array (zero-based index)
   index(VALUE)     - Return the zero-based index of VALUE within arrays or strings
+  indices(VALUE)   - Return every index where VALUE occurs within arrays or strings
   group_by(KEY)    - Group array items by field
   group_count(KEY) - Count grouped items by field
   join(SEPARATOR)  - Join array elements with a string

--- a/t/indices.t
+++ b/t/indices.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "tags": ["perl", "json", "perl", "cli"],
+  "phrase": "banana",
+  "users": [
+    {"name": "Alice"},
+    {"name": "Bob"},
+    {"name": "Alice"}
+  ],
+  "numbers": [1, 2, 3, 2, 1],
+  "mixed": [true, false, true],
+  "items": [1, null, 2, null]
+});
+
+my $jq = JQ::Lite->new;
+
+my @tag_indices = $jq->run_query($json, '.tags | indices("perl")');
+is_deeply($tag_indices[0], [0, 2], 'indices() finds all matching array positions');
+
+my @user_indices = $jq->run_query($json, '.users | indices({"name":"Alice"})');
+is_deeply($user_indices[0], [0, 2], 'indices() performs deep comparisons for arrays of hashes');
+
+my @number_indices = $jq->run_query($json, '.numbers | indices(2)');
+is_deeply($number_indices[0], [1, 3], 'indices() handles numeric comparisons');
+
+my @bool_indices = $jq->run_query($json, '.mixed | indices(true)');
+is_deeply($bool_indices[0], [0, 2], 'indices() works with JSON::PP::Boolean values');
+
+my @null_indices = $jq->run_query($json, '.items | indices(null)');
+is_deeply($null_indices[0], [1, 3], 'indices() treats null as undef when scanning arrays');
+
+my @string_indices = $jq->run_query($json, '.phrase | indices("an")');
+is_deeply($string_indices[0], [1, 3], 'indices() lists every substring occurrence');
+
+my @empty_fragment = $jq->run_query($json, '.phrase | indices("")');
+is_deeply($empty_fragment[0], [0, 1, 2, 3, 4, 5, 6], 'indices("") returns every string boundary');
+
+my @no_match = $jq->run_query($json, '.tags | indices("python")');
+is_deeply($no_match[0], [], 'indices() returns an empty array when no matches exist');
+
+my @undef_string = $jq->run_query($json, '.phrase | indices(null)');
+is_deeply($undef_string[0], [], 'string searches with null yield an empty array');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add an indices(value) helper that emits every index where a value appears within arrays or strings, mirroring jq
- document the new helper across README, CLI help, POD, and the changelog
- add regression coverage exercising array, string, boolean, and null inputs

## Testing
- prove -l

------
https://chatgpt.com/codex/tasks/task_e_68ea49a1d3d88330bccaf877b8eeadeb