### PR TITLE
Add jq-compatible all() helper

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.92  2025-10-11
+    [Feature]
+    - Added all([filter]) helper mirroring jq's all/0 and all/1 behaviour,
+      requiring every evaluated value to be truthy. Documented the helper
+      across README, POD, CLI help, and regression tests.
+
 0.91  2025-10-11
     [Feature]
     - Added indices(value) helper to emit every index where the supplied value

--- a/MANIFEST
+++ b/MANIFEST
@@ -7,6 +7,7 @@ MANIFEST.SKIP
 README.md
 t/abs.t
 t/aggregate.t
+t/all.t
 t/any.t
 t/avg_by.t
 t/arithmetic.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -93,6 +93,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `has(key)` | Check if objects contain a key or arrays have an index (v0.71) |
 | `contains(value)` | Check whether strings include the value or arrays contain an element (v0.56) |
 | `any([filter])` | Return true when any input (optionally filtered) is truthy (v0.90) |
+| `all([filter])` | Return true when every input (optionally filtered) is truthy (v0.92) |
 | `group_by(key)`| Group array items by field                           |
 | `group_count(key)` | Count how many items fall under each key (v0.46)   |
 | `sum_by(path)` | Sum numeric values projected from each array item (v0.68) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -387,6 +387,7 @@ Supported Functions:
   has              - Check if objects contain a key or arrays expose an index
   contains         - Check if strings include a fragment, arrays contain an element, or hashes have a key
   any([FILTER])    - Return true if any input (optionally filtered) is truthy
+  all([FILTER])    - Return true if every input (optionally filtered) is truthy
   match("pattern") - Match string using regex
   explode()        - Convert strings to arrays of Unicode code points
   implode()        - Turn arrays of code points back into strings

--- a/t/all.t
+++ b/t/all.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my @array_true = $jq->run_query('[true, 1, "non-empty"]', 'all');
+ok($array_true[0], 'all returns true when every array element is truthy');
+
+my @array_false = $jq->run_query('[true, false, 1]', 'all');
+ok(!$array_false[0], 'all returns false when any array element is falsy');
+
+my @array_empty = $jq->run_query('[]', 'all');
+ok($array_empty[0], 'all returns true for an empty array (vacuous truth)');
+
+my @filter_true = $jq->run_query('[{"active":true},{"active":1}]', 'all(.active)');
+ok($filter_true[0], 'all(filter) returns true when filter is truthy for every element');
+
+my @filter_false = $jq->run_query('[{"active":true},{}]', 'all(.active)');
+ok(!$filter_false[0], 'all(filter) returns false when filter fails for any element');
+
+my @scalar_true = $jq->run_query('true', 'all');
+ok($scalar_true[0], 'all on a scalar truthy value returns true');
+
+my @scalar_false = $jq->run_query('0', 'all');
+ok(!$scalar_false[0], 'all on a scalar falsy value returns false');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add jq's `all([filter])` helper with documentation and CLI updates
- document the new helper in README and Changes
- add regression tests covering array, filter, and scalar behaviour

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68ea4dac09c8833086bd856f6c6460a7