### PR TITLE
Add jq-compatible map_values filter

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+0.92  2025-10-11
+    [Feature]
+    - Added map_values(filter) helper to transform every value within objects
+      using jq-compatible filter semantics, dropping keys when the filter
+      yields no result and recursing through arrays of objects. Documented the
+      helper across README, POD, CLI help, and regression tests.
+
 0.91  2025-10-11
     [Feature]
     - Added indices(value) helper to emit every index where the supplied value

--- a/MANIFEST
+++ b/MANIFEST
@@ -37,6 +37,7 @@ t/keys_unsorted.t
 t/limit.t
 t/length.t
 t/map.t
+t/map_values.t
 t/merge_objects.t
 t/median_by.t
 t/median.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `map`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `map`, `map_values()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -65,6 +65,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `enumerate()`  | Pair each array element with its zero-based index (v0.81) |
 | `transpose()`  | Convert arrays-of-arrays from rows into columns, truncating to the shortest length (v0.82) |
 | `map(expr)`    | Map/filter values using a subquery                   |
+| `map_values(filter)` | Apply a filter to every value in an object, dropping keys when the filter yields no result (v0.92) |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `pick(keys...)` | Build objects containing only the specified keys (v0.74) |
 | `merge_objects()` | Shallow-merge arrays of objects into a single hash with last-write-wins semantics (v0.80) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -346,6 +346,8 @@ Supported Functions:
   transpose()      - Rotate arrays-of-arrays from rows into columns
   count            - Count total number of matching items
   map(EXPR)        - Map/filter array items with a subquery
+  map_values(FILTER)
+                   - Apply FILTER to each value in an object (dropping keys when FILTER yields no result)
   add / sum        - Sum all numeric values in an array
   sum_by(KEY)      - Sum numeric values projected from each array item
   avg_by(KEY)      - Average numeric values projected from each array item

--- a/t/map_values.t
+++ b/t/map_values.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my $length_json = '{"one":[1,2],"two":[3]}';
+my @lengths     = $jq->run_query($length_json, 'map_values(length)');
+is_deeply($lengths[0], { one => 2, two => 1 }, 'map_values(length) transforms each value within an object');
+
+my $filter_json = '{"keep":{"value":1},"drop":{"value":0}}';
+my @filtered    = $jq->run_query($filter_json, 'map_values(select(.value > 0))');
+is_deeply($filtered[0], { keep => { value => 1 } }, 'map_values(select(.value > 0)) removes entries whose nested values fail the filter');
+
+my $array_json = q([
+  {"counts": [1, 2, 3]},
+  {"counts": []}
+]);
+my @array_results = $jq->run_query($array_json, 'map_values(length)');
+is_deeply($array_results[0], [
+    { counts => 3 },
+    { counts => 0 },
+], 'map_values(length) processes arrays of objects element-wise');
+
+my @emptied = $jq->run_query($length_json, 'map_values(empty)');
+is_deeply($emptied[0], {}, 'map_values(empty) drops keys when the filter yields no result');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add support for the jq-style `map_values(filter)` helper within the core engine
- document the new helper across the README, module POD, CLI help, and changelog
- cover object and array behaviour with new regression tests and update the MANIFEST

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68ea4dac09c8833086bd856f6c6460a7