### PR TITLE
Handle unknown CLI options

### DIFF
--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -162,6 +162,9 @@ USAGE
         $filename = $arg;
     }
     # If not a file and query is not yet set, treat it as the query string
+    elsif ($arg =~ /^-/) {
+        die "[ERROR] Unknown option: $arg\n";
+    }
     elsif (!defined $query) {
         $query = $arg;
     }


### PR DESCRIPTION
## Summary
- detect unrecognized command-line flags passed to jq-lite
- exit early with a clear error message when an unknown option is provided

## Testing
- printf '{}\n' | bin/jq-lite -va

------
https://chatgpt.com/codex/tasks/task_e_68ead903f8c08330868b1793913f754b