### PR TITLE
Remove debug logging from sort_by

### DIFF
--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -979,9 +979,7 @@ sub run_query {
                     my @sorted = sort {
                         my $a_val = (_traverse($a, $key_path))[0] // '';
                         my $b_val = (_traverse($b, $key_path))[0] // '';
-        
-                        warn "[DEBUG] a=$a_val, b=$b_val => cmp=" . $cmp->($a_val, $b_val) . "\n";
-        
+
                         $cmp->($a_val, $b_val);
                     } @$item;
         


### PR DESCRIPTION
## Summary
- remove the unconditional debug warning from the sort_by comparator so tests match the standard output

## Testing
- prove -l t/sort_by.t
- prove -l t

------
https://chatgpt.com/codex/tasks/task_e_68eae16041148330b6711377b9365187