### PR TITLE
Add jq-compatible tojson helper

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,14 @@
 0.93  2025-10-12
     [Feature]
+    - Added tojson() helper to encode any value as JSON text, mirroring jq's
+      tojson/0 behavior and complementing existing tostring(). Documented the
+      helper across README, POD, CLI help, and regression tests.
+    [Tests]
+    - Added regression coverage for tojson() to ensure strings, numbers,
+      booleans, nulls, arrays, and objects emit the expected JSON text.
+    [Docs]
+    - Documented tojson() across README, POD, CLI help listings, and function
+      tables alongside existing string helpers.
     - Added delpaths(paths) helper to delete multiple keys or indices using
       jq-compatible path arrays evaluated via arbitrary filters. Updated the
       documentation and regression tests accordingly.

--- a/MANIFEST
+++ b/MANIFEST
@@ -64,6 +64,7 @@ t/transpose.t
 t/substr.t
 t/startswith_endswith.t
 t/to_number.t
+t/tojson.t
 t/tostring.t
 t/unique_by.t
 t/trim.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `map`, `map_values()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `delpaths()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `map`, `map_values()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `delpaths()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -79,6 +79,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `round`       | Round numbers to the nearest integer (v0.54)           |
 | `clamp(min, max)` | Clamp numbers within an inclusive range (v0.73)        |
 | `tostring`    | Convert values to their JSON string representation (v0.85) |
+| `tojson`      | Encode any value as JSON text (unreleased)                |
 | `to_number`   | Convert numeric-looking strings/booleans to numbers (v0.72) |
 | `trim`        | Remove leading/trailing whitespace from strings (v0.50) |
 | `ltrimstr(prefix)` | Remove `prefix` from the start of strings when present (v0.87) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -350,6 +350,7 @@ Supported Functions:
   round()          - Round numbers to the nearest integer (half-up semantics)
   clamp(MIN, MAX)  - Clamp numeric values within an inclusive range
   tostring()       - Convert values into their JSON string representation
+  tojson()         - Encode values as JSON text regardless of type
   to_number()      - Coerce numeric-looking strings/booleans into numbers
   nth(N)           - Get the Nth element of an array (zero-based index)
   index(VALUE)     - Return the zero-based index of VALUE within arrays or strings

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -742,6 +742,13 @@ sub run_query {
             next;
         }
 
+        # support for tojson()
+        if ($part eq 'tojson()' || $part eq 'tojson') {
+            @next_results = map { _apply_tojson($_) } @results;
+            @results = @next_results;
+            next;
+        }
+
         # support for to_number()
         if ($part eq 'to_number()' || $part eq 'to_number') {
             @next_results = map { _apply_to_number($_) } @results;
@@ -1579,6 +1586,12 @@ sub _apply_tostring {
     if (ref $value eq 'ARRAY' || ref $value eq 'HASH') {
         return encode_json($value);
     }
+
+    return encode_json($value);
+}
+
+sub _apply_tojson {
+    my ($value) = @_;
 
     return encode_json($value);
 }
@@ -2905,7 +2918,7 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, keys_unsorted, values, first, last, reverse, sort, sort_desc, sort_by, min_by, max_by, unique, unique_by, has, contains, group_by, group_count, join, split, explode, implode, count, empty, type, nth, del, delpaths, compact, upper, lower, titlecase, abs, ceil, floor, trim, ltrimstr, rtrimstr, substr, slice, startswith, endswith, add, sum, sum_by, avg_by, median_by, product, min, max, avg, median, mode, percentile, variance, stddev, drop, tail, chunks, range, enumerate, transpose, flatten_all, flatten_depth, clamp, to_number, pick, merge_objects, to_entries, from_entries, with_entries, map_values, paths, indices
+=item * Built-in functions: length, keys, keys_unsorted, values, first, last, reverse, sort, sort_desc, sort_by, min_by, max_by, unique, unique_by, has, contains, group_by, group_count, join, split, explode, implode, count, empty, type, nth, del, delpaths, compact, upper, lower, titlecase, abs, ceil, floor, trim, ltrimstr, rtrimstr, substr, slice, startswith, endswith, add, sum, sum_by, avg_by, median_by, product, min, max, avg, median, mode, percentile, variance, stddev, drop, tail, chunks, range, enumerate, transpose, flatten_all, flatten_depth, clamp, tostring, tojson, to_number, pick, merge_objects, to_entries, from_entries, with_entries, map_values, paths, indices
 
 =item * Supports map(...), map_values(...), limit(n), drop(n), tail(n), chunks(n), range(...), and enumerate() style transformations
 
@@ -3521,6 +3534,19 @@ Example:
 
   .score   | tostring   # => "42"
   .profile | tostring   # => "{\"name\":\"Alice\"}"
+
+=item * tojson()
+
+Encodes the current value as JSON text regardless of its original type,
+mirroring jq's C<tojson>. Scalars, booleans, nulls, arrays, and objects all
+produce a JSON string, allowing raw string inputs to be re-escaped safely for
+embedding or subsequent decoding.
+
+Example:
+
+  .score   | tojson   # => "42"
+  .name    | tojson   # => "\"Alice\""
+  .profile | tojson   # => "{\"name\":\"Alice\"}"
 
 =item * to_number()
 

--- a/t/tojson.t
+++ b/t/tojson.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use Test::More;
+use JSON::PP;
+use JQ::Lite;
+
+my $json = q({
+  "num": 42,
+  "str": "hello",
+  "flag": true,
+  "maybe": null,
+  "arr": [1, "two", false],
+  "obj": {"name": "Alice", "age": 30}
+});
+
+my $jq = JQ::Lite->new;
+
+my @number = $jq->run_query($json, '.num | tojson');
+is($number[0], '42', 'tojson emits JSON for numeric scalars');
+
+my @string = $jq->run_query($json, '.str | tojson');
+is($string[0], '"hello"', 'tojson re-escapes plain strings as JSON text');
+
+my @boolean = $jq->run_query($json, '.flag | tojson');
+is($boolean[0], 'true', 'tojson encodes booleans using JSON literals');
+
+my @null = $jq->run_query($json, '.maybe | tojson');
+is($null[0], 'null', 'tojson encodes null/undef as the literal null');
+
+my @array = $jq->run_query($json, '.arr | tojson');
+my $decoded_array = JSON::PP->new->decode($array[0]);
+is_deeply($decoded_array, [1, 'two', JSON::PP::false], 'tojson encodes arrays as JSON text');
+
+my @object = $jq->run_query($json, '.obj | tojson');
+my $decoded_object = JSON::PP->new->decode($object[0]);
+is_deeply($decoded_object, { name => 'Alice', age => 30 }, 'tojson encodes objects as JSON text');
+
+my @missing = $jq->run_query($json, '.missing? | tojson');
+if (@missing) {
+    is($missing[0], 'null', 'tojson treats optional missing values as JSON null');
+} else {
+    pass('optional path produced no results to encode');
+}
+
+my @raw = $jq->run_query('["foo", "bar"]', 'tojson');
+is($raw[0], '["foo","bar"]', 'top-level arrays are encoded as JSON text');
+
+my @raw_string = $jq->run_query('"hi"', 'tojson');
+is($raw_string[0], '"hi"', 'top-level strings retain JSON escaping');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a jq-style `tojson` helper that always emits JSON text
- document the new helper across README, CLI help, and module POD
- cover the helper with new regression tests and manifest entry

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68eae9c83a2c8330b5bbc4753a205fdc