### PR TITLE
Add walk(filter) helper for recursive transformations

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,13 @@
+0.95  2025-10-12
+    [Feature]
+    - Added walk(filter) helper to recursively traverse arrays and objects while
+      applying jq-compatible filters to every value.
+    [Tests]
+    - Added regression coverage for walk() to ensure nested scalars and arrays
+      are transformed recursively.
+    [Docs]
+    - Documented walk() across README, POD, and --help-functions listings.
+
 0.94  2025-10-12
     [Feature]
     - Added all([filter]) helper mirroring jq's all/0 and all/1 semantics for

--- a/MANIFEST
+++ b/MANIFEST
@@ -71,4 +71,5 @@ t/unique_by.t
 t/trim.t
 t/trimstr.t
 t/values.t
+t/walk.t
 LICENSE

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `map`, `map_values()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `delpaths()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `map`, `map_values()`, `walk()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `delpaths()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -66,6 +66,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `transpose()`  | Convert arrays-of-arrays from rows into columns, truncating to the shortest length (v0.82) |
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `map_values(filter)` | Apply a filter to every value in an object, dropping keys when the filter yields no result (v0.92) |
+| `walk(filter)` | Recursively apply a filter to every value within arrays and objects (v0.95) |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `pick(keys...)` | Build objects containing only the specified keys (v0.74) |
 | `merge_objects()` | Shallow-merge arrays of objects into a single hash with last-write-wins semantics (v0.80) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -330,6 +330,7 @@ Supported Functions:
   map(EXPR)        - Map/filter array items with a subquery
   map_values(FILTER)
                    - Apply FILTER to each value in an object (dropping keys when FILTER yields no result)
+  walk(FILTER)     - Recursively apply FILTER to every value in arrays and objects
   add / sum        - Sum all numeric values in an array
   sum_by(KEY)      - Sum numeric values projected from each array item
   avg_by(KEY)      - Average numeric values projected from each array item

--- a/t/walk.t
+++ b/t/walk.t
@@ -1,0 +1,47 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my $object_json = q({
+  "name": "alice",
+  "profile": {
+    "roles": ["dev", "ops"],
+    "note": "team lead"
+  }
+});
+
+my @object_results = $jq->run_query($object_json, 'walk(upper)');
+
+is_deeply(
+    $object_results[0],
+    {
+        name    => 'ALICE',
+        profile => {
+            roles => [ 'DEV', 'OPS' ],
+            note  => 'TEAM LEAD',
+        },
+    },
+    'walk(upper) recursively uppercases nested string values'
+);
+
+my $array_json = q(["HELLO", ["WORLD", "PERL"]]);
+my @array_results = $jq->run_query($array_json, 'walk(lower)');
+
+is_deeply(
+    $array_results[0],
+    [ 'hello', [ 'world', 'perl' ] ],
+    'walk(lower) applies filter recursively within nested arrays'
+);
+
+my @scalar_results = $jq->run_query('"hello"', 'walk(tostring)');
+
+is(
+    $scalar_results[0],
+    'hello',
+    'walk(tostring) applies filter to scalar values'
+);
+
+done_testing;


### PR DESCRIPTION
## Summary
- add support for the jq walk(filter) helper and internal implementation
- document the new helper across README, POD, CLI help, and changelog entries
- cover the feature with regression tests and update the manifest listing

## Testing
- `prove -l t`


------
https://chatgpt.com/codex/tasks/task_e_68eb03cc2edc83309ce59abda58ab22a