### PR TITLE
Bump version to 0.96 for leaf_paths release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,13 @@
+0.96  2025-10-12
+    [Feature]
+    - Added leaf_paths() helper mirroring jq's paths(scalars) traversal to
+      emit only terminal key/index chains.
+    [Tests]
+    - Added regression coverage for leaf_paths() to ensure arrays, objects,
+      and scalars produce the correct terminal paths.
+    [Docs]
+    - Documented leaf_paths() in README, module POD, and CLI helper listings.
+
 0.95  2025-10-12
     [Feature]
     - Added walk(filter) helper to recursively traverse arrays and objects while

--- a/MANIFEST
+++ b/MANIFEST
@@ -35,6 +35,7 @@ t/index.t
 t/indices.t
 t/join.t
 t/keys_unsorted.t
+t/leaf_paths.t
 t/limit.t
 t/length.t
 t/map.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `map`, `map_values()`, `walk()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `delpaths()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `map`, `map_values()`, `walk()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `delpaths()`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -119,6 +119,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `titlecase()`  | Convert scalars (and array elements) to title case (v0.69) |
 | `path()`       | Return keys (for objects) or indices (for arrays) (v0.40) |
 | `paths()`      | Emit every path to nested values as arrays of keys/indices (v0.89) |
+| `leaf_paths()` | Emit only the paths that terminate in non-container values (v0.96) |
 | `is_empty`     | True when the value is an empty array or object (v0.41)   |
 | `default(value)` | Substitute a fallback value when the result is undef/null (v0.42) |
 

--- a/t/leaf_paths.t
+++ b/t/leaf_paths.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use Test::More tests => 6;
+use JSON::PP;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+# --- 1. Nested object with arrays and booleans
+my $json1 = '{"user":{"name":"Alice","tags":["perl","json"],"active":true}}';
+my @result1 = $jq->run_query($json1, 'leaf_paths');
+is_deeply(
+    $result1[0],
+    [
+        [ 'user', 'active' ],
+        [ 'user', 'name' ],
+        [ 'user', 'tags', 0 ],
+        [ 'user', 'tags', 1 ],
+    ],
+    'leaf_paths() includes only terminal (non-container) paths',
+);
+
+# --- 2. Mixed array contents with nested objects
+my $json2 = '[1,{"foo":[2,null]}]';
+my @result2 = $jq->run_query($json2, 'leaf_paths');
+is_deeply(
+    $result2[0],
+    [
+        [ 0 ],
+        [ 1, 'foo', 0 ],
+        [ 1, 'foo', 1 ],
+    ],
+    'leaf_paths() traverses arrays while skipping intermediate containers',
+);
+
+# --- 3. Scalar input returns the empty path
+my $json3 = '"hello"';
+my @result3 = $jq->run_query($json3, 'leaf_paths');
+is_deeply($result3[0], [ [] ], 'leaf_paths() returns empty path for scalar root');
+
+# --- 4. Null input returns the empty path
+my $json4 = 'null';
+my @result4 = $jq->run_query($json4, 'leaf_paths');
+is_deeply($result4[0], [ [] ], 'leaf_paths() returns empty path for null root');
+
+# --- 5. Empty containers yield no leaf paths
+my $json5 = '{"items":[]}';
+my @result5 = $jq->run_query($json5, 'leaf_paths');
+is_deeply($result5[0], [], 'leaf_paths() ignores empty arrays and objects');
+
+# --- 6. Boolean values are treated as leaves
+my $json6 = '{"flag":false}';
+my @result6 = $jq->run_query($json6, 'leaf_paths');
+is_deeply($result6[0], [ [ 'flag' ] ], 'leaf_paths() treats booleans as scalars');
+


### PR DESCRIPTION
## Summary
- bump JQ::Lite's version metadata to 0.96 to cover the new leaf_paths helper
- record the 0.96 release notes in Changes with feature, tests, and docs updates

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68eb97b583e48330b72523ad6f94dfae