### PR TITLE
Add jq-compatible objects filter

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,14 @@
+0.100  2025-10-13
+    [Feature]
+    - Added objects helper mirroring jq's objects/0 filter to pass through only
+      hash inputs while skipping scalars and arrays.
+    [Tests]
+    - Added regression coverage ensuring objects() mirrors jq semantics for
+      arrays, scalars, and nested objects.
+    [Docs]
+    - Documented objects across README, module POD, helper listings, and
+      updated MANIFEST.
+
 0.99  2025-10-13
     [Feature]
     - Added arrays helper mirroring jq's arrays/0 filter to pass through only

--- a/MANIFEST
+++ b/MANIFEST
@@ -43,6 +43,7 @@ t/length.t
 t/map.t
 t/map_values.t
 t/merge_objects.t
+t/objects.t
 t/median_by.t
 t/median.t
 t/mode.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `map`, `map_values()`, `walk()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `delpaths()`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `map`, `map_values()`, `walk()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `delpaths()`, `arrays`, `objects`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -108,6 +108,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `flatten_all()`| Recursively flatten nested arrays into a single array (v0.67) |
 | `flatten_depth(n)` | Flatten nested arrays up to `n` levels deep (v0.70) |
 | `arrays`       | Emit input values only when they are arrays (v0.99) |
+| `objects`      | Emit input values only when they are objects (v0.100) |
 | `type()`       | Return the type of the value ("string", "number", "boolean", "array", "object", "null") (v0.36) |
 | `nth(n)`       | Get the nth element of an array (v0.37)              |
 | `index(value)` | Return the zero-based index of the first match in arrays or strings (v0.65) |

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -6,7 +6,7 @@ use JSON::PP;
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 
-our $VERSION = '0.99';
+our $VERSION = '0.100';
 
 sub new {
     my ($class, %opts) = @_;
@@ -1037,6 +1037,15 @@ sub run_query {
         if ($part eq 'arrays()' || $part eq 'arrays') {
             @next_results = map {
                 ref $_ eq 'ARRAY' ? $_ : ()
+            } @results;
+            @results = @next_results;
+            next;
+        }
+
+        # support for objects
+        if ($part eq 'objects()' || $part eq 'objects') {
+            @next_results = map {
+                ref $_ eq 'HASH' ? $_ : ()
             } @results;
             @results = @next_results;
             next;
@@ -3189,7 +3198,7 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, keys_unsorted, values, first, last, reverse, sort, sort_desc, sort_by, min_by, max_by, unique, unique_by, has, contains, any, all, group_by, group_count, join, split, explode, implode, count, empty, type, nth, del, delpaths, compact, upper, lower, titlecase, abs, ceil, floor, trim, ltrimstr, rtrimstr, substr, slice, startswith, endswith, add, sum, sum_by, avg_by, median_by, product, min, max, avg, median, mode, percentile, variance, stddev, drop, tail, chunks, range, enumerate, transpose, flatten_all, flatten_depth, clamp, tostring, tojson, to_number, pick, merge_objects, to_entries, from_entries, with_entries, map_values, walk, paths, leaf_paths, index, rindex, indices
+=item * Built-in functions: length, keys, keys_unsorted, values, first, last, reverse, sort, sort_desc, sort_by, min_by, max_by, unique, unique_by, has, contains, any, all, group_by, group_count, join, split, explode, implode, count, empty, type, nth, del, delpaths, compact, upper, lower, titlecase, abs, ceil, floor, trim, ltrimstr, rtrimstr, substr, slice, startswith, endswith, add, sum, sum_by, avg_by, median_by, product, min, max, avg, median, mode, percentile, variance, stddev, drop, tail, chunks, range, enumerate, transpose, flatten_all, flatten_depth, clamp, tostring, tojson, to_number, pick, merge_objects, to_entries, from_entries, with_entries, map_values, walk, paths, leaf_paths, index, rindex, indices, arrays, objects
 
 =item * Supports map(...), map_values(...), walk(...), limit(n), drop(n), tail(n), chunks(n), range(...), and enumerate() style transformations
 
@@ -3541,6 +3550,18 @@ Example:
   .items[] | arrays
 
 Returns only the array entries from C<.items>.
+
+=item * objects
+
+Emits its input only when the value is a hash reference, mirroring jq's
+C<objects> filter. Scalars and arrays yield no output, letting you isolate
+objects inside heterogeneous streams.
+
+Example:
+
+  .items[] | objects
+
+Returns only the object entries from C<.items>.
 
 =item * type()
 

--- a/t/objects.t
+++ b/t/objects.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = <<'JSON';
+{
+  "items": [
+    [1, 2, 3],
+    {"note": "object"},
+    {"type": "also object"},
+    "scalar",
+    42,
+    null
+  ]
+}
+JSON
+
+my $jq = JQ::Lite->new;
+my @results = $jq->run_query($json, '.items[] | objects');
+
+is_deeply(\@results, [
+    { note => 'object' },
+    { type => 'also object' },
+], 'objects returns only hash inputs when iterating arrays');
+
+@results = $jq->run_query($json, '.items[1] | objects');
+
+is_deeply(\@results, [ { note => 'object' } ], 'objects passes through object inputs unchanged');
+
+@results = $jq->run_query($json, '.items[0] | objects');
+
+is_deeply(\@results, [], 'objects yields empty result when input is not an object');
+
+@results = $jq->run_query($json, '.items | objects');
+
+is_deeply(\@results, [], 'objects yields no output for non-object top-level input');
+
+done_testing();


### PR DESCRIPTION
## Summary
- add an `objects` helper so jq-lite can emit only hash inputs like jq's `objects/0`
- document the new helper, bump the distribution version, and list the new test in the manifest
- add regression coverage confirming `objects` skips scalars and arrays while passing objects through

## Testing
- prove -l t/objects.t

------
https://chatgpt.com/codex/tasks/task_e_68ec7472efe0833097d35c12c59c0f0a