### PR TITLE
Fix whitespace trimming for Perl 5.10 compatibility

### DIFF
--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -25,7 +25,11 @@ sub run_query {
     }
     
     # instead of: my @parts = split /\|/, $query;
-    my @parts = map { s/^\s+|\s+$//gr } split /\|/, $query;
+    my @parts = map {
+        my $part = $_;
+        $part =~ s/^\s+|\s+$//g;
+        $part;
+    } split /\|/, $query;
     
     # detect .[] and convert to pseudo-command
     @parts = map {
@@ -2875,7 +2879,11 @@ sub _parse_arguments {
     }
 
     my @parts = split /,/, $raw;
-    return map { s/^\s+|\s+$//gr } @parts;
+    return map {
+        my $part = $_;
+        $part =~ s/^\s+|\s+$//g;
+        $part;
+    } @parts;
 }
 
 sub _parse_range_arguments {


### PR DESCRIPTION
## Summary
- replace uses of the `/r` substitution modifier so trimming works on Perl 5.10
- keep behavior by trimming via temporary copies in `run_query` and `_parse_arguments`

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68ecd30bbf548330aeb7dcc606bf9c07