### PR TITLE
Add jq-compatible numbers filter

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,15 @@
+0.103  2025-10-13
+    [Feature]
+    - Added numbers helper mirroring jq's numbers/0 filter to emit only numeric
+      scalars decoded from JSON input while skipping strings, booleans, arrays,
+      and objects.
+    [Tests]
+    - Added regression coverage ensuring numbers() accepts integers, floats, and
+      zero while rejecting booleans, arrays, and numeric-looking strings.
+    [Docs]
+    - Documented numbers across README, module POD, CLI helper listings, and
+      updated MANIFEST.
+
 0.102  2025-10-13
     [Feature]
     - Added not helper mirroring jq's logical negation semantics, yielding

--- a/MANIFEST
+++ b/MANIFEST
@@ -49,6 +49,7 @@ t/median_by.t
 t/median.t
 t/mode.t
 t/not.t
+t/numbers.t
 t/min_max_by.t
 t/match.t
 t/match_i.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `not`, `map`, `map_values()`, `walk()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `delpaths()`, `arrays`, `objects`, `scalars`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `not`, `map`, `map_values()`, `walk()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `delpaths()`, `arrays`, `objects`, `scalars`, `numbers`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -110,7 +110,8 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `flatten_depth(n)` | Flatten nested arrays up to `n` levels deep (v0.70) |
 | `arrays`       | Emit input values only when they are arrays (v0.99) |
 | `objects`      | Emit input values only when they are objects (v0.100) |
-| `scalars`      | Emit input values only when they are scalars (strings, numbers, booleans, null) (unreleased) |
+| `scalars`      | Emit input values only when they are scalars (strings, numbers, booleans, null) (v0.101) |
+| `numbers`      | Emit input values only when they are numeric scalars (v0.103) |
 | `type()`       | Return the type of the value ("string", "number", "boolean", "array", "object", "null") (v0.36) |
 | `nth(n)`       | Get the nth element of an array (v0.37)              |
 | `index(value)` | Return the zero-based index of the first match in arrays or strings (v0.65) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -383,6 +383,9 @@ Supported Functions:
   flatten_all()    - Recursively flatten nested arrays into a single array
   flatten_depth(N) - Flatten nested arrays up to N levels deep
   arrays           - Pass through inputs that are arrays, discarding others
+  objects          - Pass through inputs that are objects, discarding others
+  scalars          - Pass through inputs that are scalars (strings, numbers, booleans, null)
+  numbers          - Pass through inputs that are numeric scalars, discarding others
   del(KEY)         - Remove a key from objects in the result
   compact          - Remove undefined values from arrays
   path             - Return available keys for objects or indexes for arrays

--- a/t/numbers.t
+++ b/t/numbers.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = <<'JSON';
+{
+  "items": [
+    3,
+    "4",
+    -7.5,
+    true,
+    null,
+    {"note": "object"},
+    [1, 2]
+  ],
+  "score": 0,
+  "flag": false
+}
+JSON
+
+my $jq = JQ::Lite->new;
+my @results = $jq->run_query($json, '.items[] | numbers');
+
+is_deeply(\@results, [3, -7.5], 'numbers emits only numeric entries from arrays');
+
+@results = $jq->run_query($json, '.items | numbers');
+is_deeply(\@results, [], 'numbers yields no output for array containers');
+
+@results = $jq->run_query($json, '.score | numbers');
+is($results[0], 0, 'numbers passes through zero values');
+
+@results = $jq->run_query($json, '.flag | numbers');
+is_deeply(\@results, [], 'numbers skips booleans');
+
+@results = $jq->run_query($json, '.items[1] | numbers');
+is_deeply(\@results, [], 'numbers skips numeric-looking strings');
+
+done_testing();


### PR DESCRIPTION
## Summary
- add a jq-style `numbers` helper that emits only numeric scalars using Perl SV flags to distinguish JSON numbers from strings
- document the new helper across the README, module POD, change log, CLI help, and manifest
- add regression coverage that exercises numeric, boolean, and string inputs for the `numbers` filter

## Testing
- prove -lr t/numbers.t

------
https://chatgpt.com/codex/tasks/task_e_68ecea1c6ebc8330a1e26ebcba7c674a