### PR TITLE
Add recurse helper mirroring jq depth-first traversal

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,14 @@
+0.103  2025-10-13
+    [Feature]
+    - Added recurse helper mirroring jq's recurse/0 and recurse/1 to emit the
+      current value alongside depth-first descendants using optional child
+      filters.
+    [Tests]
+    - Added regression coverage ensuring recurse() traverses nested objects,
+      arrays, and custom child relationships.
+    [Docs]
+    - Documented recurse across README, module POD, and CLI helper listings.
+
 0.102  2025-10-13
     [Feature]
     - Added not helper mirroring jq's logical negation semantics, yielding

--- a/MANIFEST
+++ b/MANIFEST
@@ -56,6 +56,7 @@ t/pipe_select_name.t
 t/percentile.t
 t/pick.t
 t/pluck.t
+t/recurse.t
 t/reverse.t
 t/rindex.t
 t/range.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `not`, `map`, `map_values()`, `walk()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `delpaths()`, `arrays`, `objects`, `scalars`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `not`, `map`, `map_values()`, `walk()`, `recurse()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `delpaths()`, `arrays`, `objects`, `scalars`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -67,6 +67,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `map(expr)`    | Map/filter values using a subquery                   |
 | `map_values(filter)` | Apply a filter to every value in an object, dropping keys when the filter yields no result (v0.92) |
 | `walk(filter)` | Recursively apply a filter to every value within arrays and objects (v0.95) |
+| `recurse([filter])` | Depth-first traversal of nested structures using an optional child filter (v0.103) |
 | `pluck(key)`   | Extract values from an array of objects (v0.43)      |
 | `pick(keys...)` | Build objects containing only the specified keys (v0.74) |
 | `merge_objects()` | Shallow-merge arrays of objects into a single hash with last-write-wins semantics (v0.80) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -331,6 +331,8 @@ Supported Functions:
   map_values(FILTER)
                    - Apply FILTER to each value in an object (dropping keys when FILTER yields no result)
   walk(FILTER)     - Recursively apply FILTER to every value in arrays and objects
+  recurse([FILTER])
+                   - Emit the current value and depth-first descendants using optional FILTER for children
   add / sum        - Sum all numeric values in an array
   sum_by(KEY)      - Sum numeric values projected from each array item
   avg_by(KEY)      - Average numeric values projected from each array item

--- a/t/recurse.t
+++ b/t/recurse.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+subtest 'recurse without filter traverses nested values' => sub {
+    my $json = q({
+      "name": "alice",
+      "roles": ["dev", "ops"]
+    });
+
+    my @results = $jq->run_query($json, 'recurse');
+
+    is(scalar @results, 5, 'emits every node including scalars');
+    is_deeply($results[0], { name => 'alice', roles => [ 'dev', 'ops' ] }, 'first result is original object');
+    is($results[1], 'alice', 'visits string value before nested array');
+    is_deeply($results[2], [ 'dev', 'ops' ], 'visits nested array');
+    is($results[3], 'dev', 'visits first array element');
+    is($results[4], 'ops', 'visits second array element');
+};
+
+subtest 'recurse with filter follows custom child relationships' => sub {
+    my $tree_json = q({
+      "name": "root",
+      "children": [
+        { "name": "child1" },
+        { "name": "child2", "children": [ { "name": "grand" } ] }
+      ]
+    });
+
+    my @names = $jq->run_query($tree_json, 'recurse(.children[]?) | .name');
+
+    is_deeply(\@names, [ 'root', 'child1', 'child2', 'grand' ], 'traverses tree depth-first applying child filter');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a recurse filter with optional child expression to traverse JSON data depth-first
- document the new helper across README, CLI help, and project changelog
- cover recurse() behaviour with focused regression tests and manifest entry

## Testing
- prove -l t/recurse.t

------
https://chatgpt.com/codex/tasks/task_e_68eceffd2bec8330b9c35dc7b56c741f