### PR TITLE
Add jq-compatible test() helper

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,15 @@
+0.104  2025-10-13
+    [Feature]
+    - Added test(pattern[, flags]) helper mirroring jq's test/1 and test/2
+      to run regular expressions with optional flag strings across scalars
+      and arrays, returning JSON booleans.
+    [Tests]
+    - Added regression coverage asserting string, numeric, array, object,
+      and invalid-pattern behaviour for the new test() helper.
+    [Docs]
+    - Documented test() across README, module POD, CLI helper listings, and
+      updated MANIFEST.
+
 0.103  2025-10-13
     [Feature]
     - Added recurse helper mirroring jq's recurse/0 and recurse/1 to emit the

--- a/MANIFEST
+++ b/MANIFEST
@@ -67,6 +67,7 @@ t/split.t
 t/slice.t
 t/sort_by.t
 t/sort_unique.t
+t/test_function.t
 t/sum_by.t
 t/tail.t
 t/transpose.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `not`, `map`, `map_values()`, `walk()`, `recurse()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `delpaths()`, `arrays`, `objects`, `scalars`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `test()`, `any()`, `all()`, `not`, `map`, `map_values()`, `walk()`, `recurse()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `delpaths()`, `arrays`, `objects`, `scalars`
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`) 
 - ✅ Command-line interface: `jq-lite`
 - ✅ Reads from STDIN or file
@@ -96,6 +96,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `slice(start, length)` | Return a subarray using zero-based indexing with optional length (negative starts count from the end) (v0.66) |
 | `has(key)` | Check if objects contain a key or arrays have an index (v0.71) |
 | `contains(value)` | Check whether strings include the value or arrays contain an element (v0.56) |
+| `test(pattern[, flags])` | Evaluate a regular expression against strings, optionally enabling jq-compatible flags (v0.104) |
 | `all([filter])` | Return true when every input (optionally filtered) is truthy (v0.94) |
 | `any([filter])` | Return true when any input (optionally filtered) is truthy (v0.90) |
 | `not` | Logical negation following jq truthiness semantics (v0.102) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -375,6 +375,8 @@ Supported Functions:
                    - Transform entries using FILTER and rebuild an object
   has              - Check if objects contain a key or arrays expose an index
   contains         - Check if strings include a fragment, arrays contain an element, or hashes have a key
+  test(PATTERN[, FLAGS])
+                  - Test strings against a regular expression with optional jq-compatible flags (i, m, s, x)
   any([FILTER])    - Return true if any input (optionally filtered) is truthy
   all([FILTER])    - Return true if every input (optionally filtered) is truthy
   not              - Logical negation following jq truthiness rules

--- a/t/test_function.t
+++ b/t/test_function.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+use Test::More;
+use JSON::PP;
+use JQ::Lite;
+
+my $json = q({
+  "title": "Hello Perl",
+  "tags": ["perl", "json", "jq"],
+  "digits": 42,
+  "items": [
+    { "name": "Alice" },
+    { "name": "Bob" }
+  ]
+});
+
+my $jq = JQ::Lite->new;
+
+my @title_match = $jq->run_query($json, '.title | test("Perl")');
+ok($title_match[0], 'title matches substring');
+
+my @case_insensitive = $jq->run_query($json, '.title | test("perl"; "i")');
+ok($case_insensitive[0], 'flags enable case-insensitive matches');
+
+my @array_results = $jq->run_query($json, '.tags | test("j")');
+is_deeply(
+    $array_results[0],
+    [ JSON::PP::false, JSON::PP::true, JSON::PP::true ],
+    'arrays yield element-wise booleans',
+);
+
+my @number_match = $jq->run_query($json, '.digits | tostring | test("\\\\d{2}")');
+ok($number_match[0], 'numbers can match after tostring conversion');
+
+my @number_raw = $jq->run_query($json, '.digits | test("\\\\d{2}")');
+ok($number_raw[0], 'numbers are matched directly when they resemble the pattern');
+
+my @no_match = $jq->run_query($json, '.title | test("^World")');
+ok(!$no_match[0], 'non-matching pattern returns false');
+
+my @invalid = $jq->run_query($json, '.title | test("(")');
+ok(!$invalid[0], 'invalid regex falls back to false without dying');
+
+my @non_scalar = $jq->run_query($json, '.items | test("Alice")');
+is_deeply(
+    $non_scalar[0],
+    [ JSON::PP::false, JSON::PP::false ],
+    'objects inside arrays yield false',
+);
+
+done_testing;


### PR DESCRIPTION
## Summary
- add support for the jq `test(pattern[, flags])` filter with jq-compatible regular expression flags
- refactor argument parsing to handle semicolon-delimited calls and compile regex patterns safely
- document the new helper and extend the CLI list plus regression tests for numeric, array, and error cases

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68ecf284b39883309aaf88715d04b561