### PR TITLE
Add jq-style assignment support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,12 @@
+0.104  2025-10-13
+    [Feature]
+    - Added assignment support for simple jq-style expressions such as
+      `.path = value`, allowing in-place updates of decoded data structures
+      within pipelines.
+    [Tests]
+    - Added regression coverage for assignments across scalars, nested hashes,
+      arrays, and null literals.
+
 0.103  2025-10-13
     [Feature]
     - Added recurse helper mirroring jq's recurse/0 and recurse/1 to emit the

--- a/MANIFEST
+++ b/MANIFEST
@@ -12,6 +12,7 @@ t/arrays.t
 t/any.t
 t/avg_by.t
 t/arithmetic.t
+t/assignment.t
 t/basic.t
 t/contains.t
 t/contains_function.t

--- a/t/assignment.t
+++ b/t/assignment.t
@@ -1,0 +1,59 @@
+use strict;
+use warnings;
+use Test::More;
+use JSON::PP qw(encode_json);
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+sub apply_query {
+    my ($data, $query) = @_;
+    my $json = encode_json($data);
+    my @results = $jq->run_query($json, $query);
+    return @results;
+}
+
+subtest 'update existing value' => sub {
+    my $data = { spec => { replicas => 1 } };
+    my ($result) = apply_query($data, '.spec.replicas = 3');
+
+    is($result->{spec}{replicas}, 3, 'replicas updated to 3');
+};
+
+subtest 'create new nested key' => sub {
+    my $data = { spec => {} };
+    my ($result) = apply_query($data, '.spec.version = "1.2.3"');
+
+    is($result->{spec}{version}, '1.2.3', 'version key created');
+};
+
+subtest 'assign from another path' => sub {
+    my $data = { spec => { replicas => 2 } };
+    my ($result) = apply_query($data, '.spec.copy = .spec.replicas');
+
+    is($result->{spec}{copy}, 2, 'value copied from other path');
+};
+
+subtest 'update array element' => sub {
+    my $data = { items => [ { value => 1 }, { value => 2 } ] };
+    my ($result) = apply_query($data, '.items[1].value = 5');
+
+    is($result->{items}[1]{value}, 5, 'second item updated');
+    is($result->{items}[0]{value}, 1, 'first item untouched');
+};
+
+subtest 'assign within root array' => sub {
+    my $data = [ { value => 1 }, { value => 2 } ];
+    my ($result) = apply_query($data, '.[0].value = 9');
+
+    is($result->[0]{value}, 9, 'first element updated');
+};
+
+subtest 'assign null literal' => sub {
+    my $data = { spec => { replicas => 4 } };
+    my ($result) = apply_query($data, '.spec.replicas = null');
+
+    ok(!defined $result->{spec}{replicas}, 'value set to null');
+};
+
+done_testing();


### PR DESCRIPTION
## Summary
- add jq-style assignment handling so filters like `.spec.replicas = 3` can update values in place
- implement assignment parsing, value resolution, and path updates for nested hashes and arrays
- bump the distribution version, document the feature, and add regression tests for assignment scenarios

## Testing
- prove -Ilib t/assignment.t
- prove -Ilib t


------
https://chatgpt.com/codex/tasks/task_e_68ed037cd1fc8330a3833fdcf82d8052