### PR TITLE
Fix flaky test in t/keys_unsorted.t caused by random hash ordering

### DIFF
--- a/t/keys_unsorted.t
+++ b/t/keys_unsorted.t
@@ -17,26 +17,26 @@ JSON
 
 my $jq = JQ::Lite->new;
 
+# --- objects ---
 my @object = $jq->run_query($json, '.object | keys_unsorted');
 my @sorted = $jq->run_query($json, '.object | keys');
 
+# Set equality: keys_unsorted (when sorted) should equal keys
 is_deeply(
     [ sort @{ $object[0] } ],
     $sorted[0],
-    'keys_unsorted returns the same keys as keys when sorted',
+    'keys_unsorted returns the same set of keys as keys (after sorting)',
 );
 
-isnt(
-    join(',', @{ $object[0] }),
-    join(',', @{ $sorted[0] }),
-    'keys_unsorted preserves unsorted ordering',
-);
+# Order of keys_unsorted is implementation-defined and may match sorted order.
+note('keys_unsorted order is implementation-defined; do not assert difference from keys');
 
+# --- arrays ---
 my @array = $jq->run_query($json, '.array | keys_unsorted');
 is_deeply($array[0], [0, 1, 2], 'keys_unsorted returns indexes for arrays');
 
+# --- scalars ---
 my @scalar = $jq->run_query($json, '.array[0] | keys_unsorted');
 ok(!defined $scalar[0], 'non-object/array inputs return undef');
 
-DONE_TESTING:
 done_testing();


### PR DESCRIPTION
This pull request fixes a flaky test in `t/keys_unsorted.t`.

The previous test assumed that `keys_unsorted` would always return a different order than `keys`.
However, since Perl’s hash key ordering is randomized, it can sometimes match the sorted order by coincidence.
As a result, the test intermittently failed with the message:

```
Failed test 'keys_unsorted preserves unsorted ordering'
got: 'first,second,third'
expected: anything else
```

### **Changes**

* Removed the unstable `isnt(...)` assertion that compared sorted and unsorted order.
* Added a `note(...)` instead, clarifying that the order of `keys_unsorted` is implementation-defined.
* Kept the existing test that verifies the *set* of keys is identical to `keys`.

### **Rationale**

`keys_unsorted` should not guarantee order; its purpose is only to return the same key set without sorting.
Testing that it differs from `keys` is not valid and causes non-deterministic failures.

### **Result**

* Test suite is now stable.
* Behavior remains consistent with jq’s specification.

