### PR TITLE
Release version 1.00 to maintain ordering

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.00   2025-10-13
+    [Maintenance]
+    - Promote the release version to 1.00 to ensure Perl's version parsing
+      keeps this release newer than the historical 0.99.
+
 0.104  2025-10-13
     [Feature]
     - Added assignment support for simple jq-style expressions such as

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -6,7 +6,7 @@ use JSON::PP;
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 
-our $VERSION = '0.104';
+our $VERSION = '1.00';
 
 sub new {
     my ($class, %opts) = @_;
@@ -3521,7 +3521,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 0.101
+Version 1.00
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
## Summary
- bump the distribution version to 1.00 so it stays newer than the historic 0.99 release
- record the maintenance update in the Changes log
- update the POD VERSION section to advertise 1.00 for readers

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68eeb90d34dc833095c2f35659b7730b