### PR TITLE
Add jq-compatible setpath helper

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@
     [Features]
     - Added jq-compatible --null-input (-n) option to jq-lite so filters can
       run against null without providing input data.
+    - Implemented jq's setpath(path; value) helper to create/update nested
+      structures using literal paths or filter-generated path arrays.
 
     [Refactor]
     - Refactored JQ::Lite to delegate query parsing and filter execution to

--- a/MANIFEST
+++ b/MANIFEST
@@ -34,6 +34,7 @@ t/getpath.t
 t/friends.t
 t/group_by.t
 t/group_count.t
+t/setpath.t
 t/has.t
 t/has_function.t
 t/index.t

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 - ✅ Optional key access (`.nickname?`)
 - ✅ Array indexing and expansion (`.users[0]`, `.users[]`)
 - ✅ `select(...)` filters with `==`, `!=`, `<`, `>`, `and`, `or`
-- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `not`, `map`, `map_values()`, `walk()`, `recurse()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `fromjson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `delpaths()`, `arrays`, `objects`, `scalars`
+- ✅ Built-in functions: `length`, `keys`, `values`, `first`, `last`, `reverse`, `sort`, `sort_desc`, `sort_by`, `min_by()`, `max_by()`, `unique`, `unique_by()`, `has`, `contains()`, `any()`, `all()`, `not`, `map`, `map_values()`, `walk()`, `recurse()`, `group_by`, `group_count`, `sum_by()`, `avg_by()`, `median_by()`, `count`, `join`, `split()`, `explode()`, `implode()`, `substr()`, `slice()`, `replace()`, `empty()`, `median`, `mode`, `percentile()`, `variance`, `stddev`, `add`, `sum`, `product`, `upper()`, `lower()`, `titlecase()`, `abs()`, `ceil()`, `floor()`, `round()`, `trim()`, `ltrimstr()`, `rtrimstr()`, `startswith()`, `endswith()`, `chunks()`, `enumerate()`, `transpose()`, `flatten_all()`, `flatten_depth()`, `range()`, `index()`, `rindex()`, `indices()`, `clamp()`, `tostring()`, `tojson()`, `fromjson()`, `to_number()`, `pick()`, `merge_objects()`, `to_entries()`, `from_entries()`, `with_entries()`, `paths()`, `leaf_paths()`, `getpath()`, `setpath()`, `delpaths()`, `arrays`, `objects`, `scalars`
 - ✅ jq-style alternative operator (`lhs // rhs`) for concise default values
 - ✅ Pipe-style queries with `.[]` (e.g. `.[] | select(...) | .name`)
 - ✅ Command-line interface: `jq-lite`
@@ -130,6 +130,7 @@ It allows you to extract, traverse, and filter JSON data using a simplified jq-l
 | `paths()`      | Emit every path to nested values as arrays of keys/indices (v0.89) |
 | `leaf_paths()` | Emit only the paths that terminate in non-container values (v0.96) |
 | `getpath(path)` | Retrieve the value(s) at the supplied path array or expression (unreleased) |
+| `setpath(path; value)` | Set or create a value at the specified path using literal or filter input (unreleased) |
 | `is_empty`     | True when the value is an empty array or object (v0.41)   |
 | `expr // fallback` | Use jq's alternative operator to supply defaults when the left side is null or missing (v1.02) |
 | `default(value)` | Substitute a fallback value when the result is undef/null (v0.42) |

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -403,6 +403,8 @@ Supported Functions:
   path             - Return available keys for objects or indexes for arrays
   paths            - Emit every path to nested values as an array of keys/indices
   getpath(PATH)    - Retrieve the value(s) at the supplied path array or expression
+  setpath(PATH; VALUE)
+                   - Set or create value(s) at a path using literal or filter input
   is_empty         - Check if an array or object is empty
   upper()          - Convert scalars and array elements to uppercase
   lower()          - Convert scalars and array elements to lowercase

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -93,7 +93,7 @@ jq-like syntax — entirely within Perl, with no external binaries or XS modules
 
 =item * Pipe-style query chaining using | operator
 
-=item * Built-in functions: length, keys, keys_unsorted, values, first, last, reverse, sort, sort_desc, sort_by, min_by, max_by, unique, unique_by, has, contains, any, all, not, group_by, group_count, join, split, explode, implode, count, empty, type, nth, del, delpaths, compact, upper, lower, titlecase, abs, ceil, floor, trim, ltrimstr, rtrimstr, substr, slice, startswith, endswith, add, sum, sum_by, avg_by, median_by, product, min, max, avg, median, mode, percentile, variance, stddev, drop, tail, chunks, range, enumerate, transpose, flatten_all, flatten_depth, clamp, tostring, tojson, fromjson, to_number, pick, merge_objects, to_entries, from_entries, with_entries, map_values, walk, paths, leaf_paths, index, rindex, indices, arrays, objects, scalars
+=item * Built-in functions: length, keys, keys_unsorted, values, first, last, reverse, sort, sort_desc, sort_by, min_by, max_by, unique, unique_by, has, contains, any, all, not, group_by, group_count, join, split, explode, implode, count, empty, type, nth, del, delpaths, compact, upper, lower, titlecase, abs, ceil, floor, trim, ltrimstr, rtrimstr, substr, slice, startswith, endswith, add, sum, sum_by, avg_by, median_by, product, min, max, avg, median, mode, percentile, variance, stddev, drop, tail, chunks, range, enumerate, transpose, flatten_all, flatten_depth, clamp, tostring, tojson, fromjson, to_number, pick, merge_objects, to_entries, from_entries, with_entries, map_values, walk, paths, leaf_paths, getpath, setpath, index, rindex, indices, arrays, objects, scalars
 
 =item * Supports map(...), map_values(...), walk(...), limit(n), drop(n), tail(n), chunks(n), range(...), and enumerate() style transformations
 
@@ -287,6 +287,20 @@ Examples:
   .profile | getpath(["name"])          # => "Alice"
   .profile | getpath(["emails", 1])     # => "alice.work\@example.com"
   .profile | getpath(paths())
+
+=item * setpath(path; value)
+
+Sets or creates a value at the supplied path, following jq's C<setpath/2>
+semantics. The first argument may be a literal JSON array or any filter that
+emits path arrays. The second argument can be a literal (including JSON
+objects/arrays) or another filter evaluated against the current input. Nested
+hashes/arrays are automatically created as needed, and the original input is
+never mutated.
+
+Examples:
+
+  .settings | setpath(["flags", "beta"]; true)
+  .user     | setpath(["profile", "full_name"]; .name)
 
 =item * pick(key1, key2, ...)
 

--- a/lib/JQ/Lite/Filters.pm
+++ b/lib/JQ/Lite/Filters.pm
@@ -1419,6 +1419,16 @@ sub apply {
             return 1;
         }
 
+        # support for setpath(path_expr; value_expr)
+        if ($part =~ /^setpath\((.*)\)$/) {
+            my $args_raw = defined $1 ? $1 : '';
+            my ($paths_expr, $value_expr) = JQ::Lite::Util::_split_semicolon_arguments($args_raw, 2);
+
+            @next_results = map { JQ::Lite::Util::_apply_setpath($self, $_, $paths_expr, $value_expr) } @results;
+            @$out_ref = @next_results;
+            return 1;
+        }
+
         # support for path()
         if ($part eq 'path') {
             @next_results = map {

--- a/t/setpath.t
+++ b/t/setpath.t
@@ -1,0 +1,120 @@
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+sub run_query {
+    my ($json, $query) = @_;
+    return [$jq->run_query($json, $query)];
+}
+
+sub encode_json {
+    my ($data) = @_;
+    require JSON::PP;
+    return JSON::PP::encode_json($data);
+}
+
+my $json = <<'JSON';
+{
+  "name": "widget",
+  "details": {
+    "dimensions": {
+      "width": 10,
+      "height": 20
+    }
+  }
+}
+JSON
+
+my $res = run_query($json, 'setpath(["details", "dimensions", "depth"]; 5)');
+
+is_deeply($res->[0], {
+    name    => 'widget',
+    details => {
+        dimensions => {
+            width  => 10,
+            height => 20,
+            depth  => 5,
+        },
+    },
+}, 'setpath() adds missing nested key');
+
+$res = run_query($json, 'setpath(["details", "dimensions", "width"]; 42)');
+
+is_deeply($res->[0], {
+    name    => 'widget',
+    details => {
+        dimensions => {
+            width  => 42,
+            height => 20,
+        },
+    },
+}, 'setpath() replaces existing value');
+
+my $array_json = <<'JSON';
+{
+  "items": [
+    { "name": "alpha" }
+  ]
+}
+JSON
+
+$res = run_query($array_json, 'setpath(["items", 1, "name"]; "beta")');
+
+is_deeply($res->[0], {
+    items => [
+        { name => 'alpha' },
+        { name => 'beta' },
+    ],
+}, 'setpath() autovivifies array entries');
+
+$res = run_query($json, 'setpath(["copy_of_name"]; .name)');
+
+is_deeply($res->[0], {
+    name         => 'widget',
+    details      => {
+        dimensions => {
+            width  => 10,
+            height => 20,
+        },
+    },
+    copy_of_name => 'widget',
+}, 'setpath() evaluates value expression as filter');
+
+$res = run_query($json, 'setpath(paths; 99)');
+
+is_deeply($res->[0], {
+    name    => 99,
+    details => {
+        dimensions => {
+            width  => 99,
+            height => 99,
+        },
+    },
+}, 'setpath() accepts path arrays from filter results');
+
+$res = run_query($json, 'setpath(["details", "dimensions"]; { "area": 200 })');
+
+is_deeply($res->[0], {
+    name    => 'widget',
+    details => {
+        dimensions => {
+            area => 200,
+        },
+    },
+}, 'setpath() clones complex replacement values');
+
+subtest 'original inputs untouched' => sub {
+    my $original = { foo => { bar => 1 } };
+    my $encoded  = encode_json($original);
+    my ($output) = $jq->run_query($encoded, 'setpath(["foo", "baz"]; 7)');
+
+    is($original->{foo}{bar}, 1, 'source structure not mutated');
+    is($output->{foo}{baz}, 7, 'new path applied to result');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary
- add support for `setpath(path; value)` including parser utilities and runtime helpers
- document the new helper in the README, CLI help, and module POD
- add regression coverage for `setpath` behaviour on nested objects and arrays

## Testing
- prove -l

------
https://chatgpt.com/codex/tasks/task_e_68f2d8de2ed483309c130620aa49e80e