### PR TITLE
Allow setpath to update root value

### DIFF
--- a/lib/JQ/Lite/Util.pm
+++ b/lib/JQ/Lite/Util.pm
@@ -555,7 +555,6 @@ sub _apply_setpath {
 
     for my $path (@paths) {
         next unless ref $path eq 'ARRAY';
-        next unless @$path;
         $result = _set_value_at_path($result, [@$path], $replacement);
     }
 


### PR DESCRIPTION
## Summary
- allow `_apply_setpath` to pass empty paths through so `setpath` can replace the root value

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68f2dccc9e488330a1fb9843eaa4ca64