### PR TITLE
Bump release version to 1.13

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,12 @@
+1.13   2025-10-18
+    [Feature]
+    - Promote the release to 1.13 to ship jq-style object constructors so
+      filters like `{ "name": .name }` emit hashes for each pipeline item.
+
+    [Tests]
+    - Include regression coverage for object constructor queries to lock in the
+      new behavior.
+
 1.12   2025-10-18
     [Feature]
     - Added jq-compatible array constructors so filters like `[.name, .age]`

--- a/MANIFEST
+++ b/MANIFEST
@@ -50,6 +50,7 @@ t/length.t
 t/map.t
 t/map_values.t
 t/merge_objects.t
+t/object_constructor.t
 t/objects.t
 t/scalars.t
 t/median_by.t

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.12';
+our $VERSION = '1.13';
 
 sub new {
     my ($class, %opts) = @_;
@@ -57,7 +57,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.12
+Version 1.13
 
 =head1 SYNOPSIS
 

--- a/t/object_constructor.t
+++ b/t/object_constructor.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = <<'JSON';
+[
+  {"name": "Alice", "age": 30},
+  {"name": "Bob",   "age": 25}
+]
+JSON
+
+my $jq = JQ::Lite->new;
+
+my @results = $jq->run_query($json, '.[] | {"name": .name}');
+
+is_deeply(
+    \@results,
+    [
+        { name => 'Alice' },
+        { name => 'Bob' },
+    ],
+    'object constructor builds hashes with selected fields',
+);
+
+@results = $jq->run_query($json, '.[] | {name: .nickname}');
+
+is_deeply(
+    \@results,
+    [
+        { name => undef },
+        { name => undef },
+    ],
+    'missing values are represented as null entries in constructed objects',
+);
+
+@results = $jq->run_query($json, '.[] | {}');
+
+is_deeply(
+    \@results,
+    [ {}, {} ],
+    'empty object constructors yield empty hashes for each input',
+);
+
+done_testing();


### PR DESCRIPTION
## Summary
- bump JQ::Lite version metadata to 1.13
- add a 1.13 change log entry covering the new object constructor feature and tests

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68f3053b378083309c63f64f71c0e1eb