### PR TITLE
Fix map object shorthand handling and boolean evaluation

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,15 @@
+1.14   2025-10-18
+    [Fixes]
+    - Expand jq-style object constructor shorthand (e.g. `{name, age}`) to
+      explicit key/value pairs so map projections emit the expected hashes.
+    - Ensure `map(...)` evaluates its filter against each array element,
+      allowing comparisons like `(.age >= 20)` to yield booleans instead of
+      null.
+
+    [Tests]
+    - Extend the map regression coverage to lock in shorthand object
+      projections and boolean evaluation on each element.
+
 1.13   2025-10-18
     [Feature]
     - Promote the release to 1.13 to ship jq-style object constructors so

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.13';
+our $VERSION = '1.14';
 
 sub new {
     my ($class, %opts) = @_;
@@ -57,7 +57,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.13
+Version 1.14
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Parser.pm
+++ b/lib/JQ/Lite/Parser.pm
@@ -3,6 +3,8 @@ package JQ::Lite::Parser;
 use strict;
 use warnings;
 
+use JQ::Lite::Util ();
+
 sub parse_query {
     my ($query) = @_;
 
@@ -33,7 +35,165 @@ sub parse_query {
         }
     } @parts;
 
+    @parts = map { _lower_object_shorthand($_) } @parts;
+
     return @parts;
+}
+
+sub _lower_object_shorthand {
+    my ($text) = @_;
+
+    return $text unless defined $text;
+    return $text if index($text, '{') == -1;
+
+    my $result = '';
+    my $len    = length $text;
+    my $i      = 0;
+    my $string;
+    my $escape = 0;
+
+    while ($i < $len) {
+        my $char = substr($text, $i, 1);
+
+        if (defined $string) {
+            $result .= $char;
+            if ($escape) {
+                $escape = 0;
+            }
+            elsif ($char eq '\\') {
+                $escape = 1;
+            }
+            elsif ($char eq $string) {
+                undef $string;
+            }
+            $i++;
+            next;
+        }
+
+        if ($char eq "'" || $char eq '"') {
+            $string = $char;
+            $result .= $char;
+            $i++;
+            next;
+        }
+
+        if ($char eq '{') {
+            my ($body, $consumed) = _extract_object_body($text, $i);
+            if (defined $body) {
+                my $lowered = _lower_object_constructor($body);
+                $result .= '{' . $lowered . '}';
+                $i += $consumed;
+                next;
+            }
+        }
+
+        $result .= $char;
+        $i++;
+    }
+
+    return $result;
+}
+
+sub _extract_object_body {
+    my ($text, $start) = @_;
+
+    my $len     = length $text;
+    my $depth   = 0;
+    my $string;
+    my $escape  = 0;
+
+    for (my $i = $start; $i < $len; $i++) {
+        my $char = substr($text, $i, 1);
+
+        if (defined $string) {
+            if ($escape) {
+                $escape = 0;
+                next;
+            }
+
+            if ($char eq '\\') {
+                $escape = 1;
+                next;
+            }
+
+            if ($char eq $string) {
+                undef $string;
+            }
+
+            next;
+        }
+
+        if ($char eq "'" || $char eq '"') {
+            $string = $char;
+            next;
+        }
+
+        if ($char eq '{') {
+            $depth++;
+            next;
+        }
+
+        if ($char eq '}') {
+            $depth--;
+            if ($depth == 0) {
+                my $body = substr($text, $start + 1, $i - $start - 1);
+                return ($body, $i - $start + 1);
+            }
+            next;
+        }
+    }
+
+    return (undef, 1);
+}
+
+sub _lower_object_constructor {
+    my ($inner) = @_;
+
+    return $inner unless defined $inner;
+
+    my @parts = JQ::Lite::Util::_split_top_level_commas($inner);
+    return $inner unless @parts;
+
+    my @transformed;
+    for my $part (@parts) {
+        next unless defined $part;
+
+        my $trimmed = $part;
+        $trimmed =~ s/^\s+|\s+$//g;
+        next if $trimmed eq '';
+
+        my ($lhs, $rhs) = JQ::Lite::Util::_split_top_level_colon($part);
+
+        if (defined $lhs && defined $rhs) {
+            my $key = $lhs;
+            $key =~ s/^\s+|\s+$//g;
+
+            my $value = _lower_object_shorthand($rhs);
+            $value =~ s/^\s+|\s+$//g;
+
+            push @transformed, "$key: $value";
+            next;
+        }
+
+        if (!defined $lhs && $trimmed =~ /^[A-Za-z_][A-Za-z0-9_]*$/) {
+            push @transformed, "$trimmed: .$trimmed";
+            next;
+        }
+
+        if (defined $lhs && !defined $rhs) {
+            my $key = $lhs;
+            $key =~ s/^\s+|\s+$//g;
+            next if $key eq '';
+            push @transformed, "$key: .$key";
+            next;
+        }
+
+        my $lowered = _lower_object_shorthand($trimmed);
+        $lowered =~ s/^\s+|\s+$//g;
+        push @transformed, $lowered if length $lowered;
+    }
+
+    return join(', ', @transformed);
 }
 
 1;

--- a/t/map.t
+++ b/t/map.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Test::More;
+use JSON::PP ();
 use JQ::Lite;
 
 my $json = q([
@@ -18,5 +19,30 @@ is_deeply($map_results[0], [{id => 15}, {id => 25}], 'map(select(.id > 10)) retu
 
 my @empty_results = $jq->run_query($json, 'map(select(.id > 100))');
 is_deeply($empty_results[0], [], 'map(select(.id > 100)) returns empty array');
+
+my $people = q([
+  {"name": "Alice", "age": 30, "city": "Tokyo"},
+  {"name": "Bob", "age": 25, "city": "Osaka"}
+]);
+
+my @projected = $jq->run_query($people, 'map({name, age})');
+is_deeply(
+    $projected[0],
+    [
+        { name => 'Alice', age => 30 },
+        { name => 'Bob',   age => 25 },
+    ],
+    'map({name, age}) expands object shorthand entries'
+);
+
+my @adults = $jq->run_query($people, 'map({name, adult: (.age >= 20)})');
+is_deeply(
+    $adults[0],
+    [
+        { name => 'Alice', adult => JSON::PP::true },
+        { name => 'Bob',   adult => JSON::PP::true },
+    ],
+    'map({name, adult: (.age >= 20)}) evaluates the filter per element'
+);
 
 done_testing;


### PR DESCRIPTION
## Summary
- lower jq-style object constructors so shorthand keys expand before evaluation
- ensure comparison expressions within map filters evaluate against the current element
- cover the regression with new map tests for shorthand objects and boolean projections
- bump release metadata to version 1.14

## Testing
- prove -lr t

------
https://chatgpt.com/codex/tasks/task_e_68f30918012883309046ea75d8fa6723