### PR TITLE
Allow YAML conversion of scalars

### DIFF
--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -287,7 +287,7 @@ sub convert_yaml_to_json {
         $data = \@docs;
     }
 
-    return JSON::PP->new->encode($data);
+    return JSON::PP->new->allow_nonref->encode($data);
 }
 
 sub _build_yaml_loader {


### PR DESCRIPTION
## Summary
- allow JSON::PP to encode non-reference YAML values when converting to JSON

## Testing
- prove t/yaml_cli.t

------
https://chatgpt.com/codex/tasks/task_e_68f7637d72748330901744501a9663bc