### PR TITLE
Allow non-reference values in JSON output

### DIFF
--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -336,7 +336,7 @@ sub colorize_json {
 # ---------- Output ----------
 sub print_results {
     my @results = @_;
-    my $pp = JSON::PP->new->utf8->canonical;
+    my $pp = JSON::PP->new->utf8->allow_nonref->canonical;
     $pp->pretty unless $compact_output;
 
     for my $r (@results) {


### PR DESCRIPTION
  [CLI]
  - Fix YAML input handling in jq-lite: allow scalar (non-ref) results to be encoded without warnings or failure by adding `allow_nonref` to the JSON::PP encoder in `print_results`. This resolves failures in t/yaml_cli.t:
      * YAML files auto-detected by extension now work as expected.
      * No warnings are emitted when parsing YAML (file or STDIN with --yaml). * Process exits successfully (status 0) on valid YAML input. (PR: GH#XX)

  [Behavior]
  - Output behavior for JSON inputs is unchanged; raw/compact/color options continue to work as before. YAML input is first converted to JSON and scalar top-level values are now treated correctly.

  [Internals]
  - Minimal code change: `JSON::PP->new->utf8->allow_nonref->canonical` in `print_results`.