### PR TITLE
Bump project version to 1.28

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.28  2025-10-24
+  [Features]
+  - Add a jq-compatible `numbers` filter that recursively emits numeric values
+    from arrays and objects while skipping numeric-looking strings.
+
 1.27  2025-10-24
   [Release]
   - Bump version to 1.27 to publish the select() predicate evaluation fixes.

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -106,6 +106,7 @@ Functions are grouped by purpose for easier lookup.
 | `arrays`  | Pass only arrays                            |
 | `objects` | Pass only objects                           |
 | `scalars` | Pass only scalars (string/number/bool/null) |
+| `numbers` | Emit all numeric values recursively         |
 
 ---
 

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -541,6 +541,7 @@ Supported Functions:
   flatten_all()    - Recursively flatten nested arrays into a single array
   flatten_depth(N) - Flatten nested arrays up to N levels deep
   arrays           - Pass through inputs that are arrays, discarding others
+  numbers          - Emit all numeric values found within the input (jq-compatible)
   del(KEY)         - Remove a key from objects in the result
   compact          - Remove undefined values from arrays
   path             - Return available keys for objects or indexes for arrays

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.27';
+our $VERSION = '1.28';
 
 sub new {
     my ($class, %opts) = @_;
@@ -57,7 +57,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.27
+Version 1.28
 
 =head1 SYNOPSIS
 

--- a/t/numbers.t
+++ b/t/numbers.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test::More;
+use JSON::PP qw(encode_json);
+use JQ::Lite;
+
+my $data = {
+    mix => [
+        1,
+        "2",
+        { nested => [3, { inner => 4 }, "skip"] },
+        JSON::PP::true,
+        JSON::PP::false,
+        undef,
+        [5, { also => 7, nope => "8" }],
+    ],
+};
+
+my $json = encode_json($data);
+my $jq   = JQ::Lite->new;
+
+my @results = $jq->run_query($json, '.mix | numbers');
+is_deeply(\@results, [1, 3, 4, 5, 7], 'numbers extracts numeric values recursively');
+
+@results = $jq->run_query($json, '.mix[] | numbers');
+is_deeply(\@results, [1, 3, 4, 5, 7], 'numbers works element-wise in pipelines');
+
+@results = $jq->run_query('"42"', 'numbers');
+is_deeply(\@results, [], 'numbers skips numeric-looking strings');
+
+@results = $jq->run_query('42', 'numbers');
+is_deeply(\@results, [42], 'numbers emits standalone numeric scalars');
+
+done_testing();


### PR DESCRIPTION
## Summary
- bump the JQ::Lite module version declaration and documentation to 1.28
- record the new jq-compatible `numbers` filter in the changelog

## Testing
- prove -l t/numbers.t

------
https://chatgpt.com/codex/tasks/task_e_68fc0704b2bc8330870030132771baed