### PR TITLE
Release version 1.30

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+1.30  2025-10-25
+  [Feature]
+  - Add a jq-compatible @tsv formatter for tab-separated output with
+    proper escaping of arrays and scalar values.
+
+  [Release]
+  - Bump version to 1.30.
+
 1.29  2025-10-25
   [Feature]
   - Add jq-compatible comma sequence handling so each branch runs against the

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -44,7 +44,7 @@ Functions are grouped by purpose for easier lookup.
 | `split(sep)`, `join(sep)`            | Split and join                       |
 | `substr(start, len)`                 | Substring extraction                 |
 | `replace(old, new)`                  | Replace substring (literal)          |
-| `@csv`                               | Format array or value as CSV row     |
+| `@csv`, `@tsv`                       | Format array or value as CSV/TSV row |
 | `explode()`, `implode()`             | String ↔ Unicode code points         |
 | `tostring`, `tojson`, `fromjson`     | Serialization utilities              |
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -17,6 +17,7 @@ t/assignment.t
 t/basic.t
 t/contains.t
 t/contains_function.t
+t/csv_format.t
 t/case_transform.t
 t/clamp.t
 t/ceil_floor.t
@@ -78,6 +79,7 @@ t/slice.t
 t/sort_by.t
 t/sort_unique.t
 t/sum_by.t
+t/tsv_format.t
 t/tail.t
 t/test_function.t
 t/transpose.t

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.29';
+our $VERSION = '1.30';
 
 sub new {
     my ($class, %opts) = @_;
@@ -57,7 +57,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.29
+Version 1.30
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Filters.pm
+++ b/lib/JQ/Lite/Filters.pm
@@ -1715,6 +1715,13 @@ sub apply {
             return 1;
         }
 
+        # support for @tsv (format array/scalar as TSV row)
+        if ($part eq '@tsv' || $part eq '@tsv()') {
+            @next_results = map { JQ::Lite::Util::_apply_tsv($_) } @results;
+            @$out_ref = @next_results;
+            return 1;
+        }
+
         # support for split("separator")
         if ($part =~ /^split\((.+)\)$/) {
             my $separator = JQ::Lite::Util::_parse_string_argument($1);

--- a/lib/JQ/Lite/Util.pm
+++ b/lib/JQ/Lite/Util.pm
@@ -2894,6 +2894,17 @@ sub _apply_csv {
     return _format_csv_field($value);
 }
 
+sub _apply_tsv {
+    my ($value) = @_;
+
+    if (ref $value eq 'ARRAY') {
+        my @fields = map { _format_tsv_field($_) } @$value;
+        return join("\t", @fields);
+    }
+
+    return _format_tsv_field($value);
+}
+
 sub _format_csv_field {
     my ($value) = @_;
 
@@ -2921,12 +2932,46 @@ sub _format_csv_field {
     return _quote_csv_text($text);
 }
 
+sub _format_tsv_field {
+    my ($value) = @_;
+
+    return '' if !defined $value;
+
+    if (ref($value) eq 'JSON::PP::Boolean') {
+        return $value ? 'true' : 'false';
+    }
+
+    if (ref $value eq 'ARRAY' || ref $value eq 'HASH') {
+        my $encoded = _encode_json($value);
+        return _escape_tsv_text($encoded);
+    }
+
+    if (ref $value) {
+        my $stringified = "$value";
+        return _escape_tsv_text($stringified);
+    }
+
+    my $text = "$value";
+    return _escape_tsv_text($text);
+}
+
 sub _quote_csv_text {
     my ($text) = @_;
 
     $text = '' unless defined $text;
     $text =~ s/"/""/g;
     return '"' . $text . '"';
+}
+
+sub _escape_tsv_text {
+    my ($text) = @_;
+
+    $text = '' unless defined $text;
+    $text =~ s/\\/\\\\/g;
+    $text =~ s/\t/\\t/g;
+    $text =~ s/\r/\\r/g;
+    $text =~ s/\n/\\n/g;
+    return $text;
 }
 
 sub _is_unquoted_csv_number {

--- a/t/tsv_format.t
+++ b/t/tsv_format.t
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = '{"row":["foo","bar","baz\tqux","line1\nline2"]}';
+
+my $jq = JQ::Lite->new;
+
+my @row = $jq->run_query($json, '.row | @tsv');
+my $expected_row = "foo\tbar\tbaz\\tqux\tline1\\nline2";
+is_deeply(\@row, [$expected_row], '@tsv formats arrays as TSV rows with escapes');
+
+my @single = $jq->run_query($json, '.row[0] | @tsv');
+is_deeply(\@single, ['foo'], '@tsv formats scalar values as TSV fields');
+
+my $mixed_json = '{"data":[true,{"k":"v"}]}';
+my @mixed = $jq->run_query($mixed_json, '.data | @tsv');
+my $expected_mixed = "true\t{\"k\":\"v\"}";
+is_deeply(\@mixed, [$expected_mixed], '@tsv stringifies booleans and objects');
+
+done_testing();


### PR DESCRIPTION
## Summary
- bump the module's version declaration and documentation to 1.30
- record the 1.30 release in the change log with the new @tsv formatter

## Testing
- prove -l t/tsv_format.t

------
https://chatgpt.com/codex/tasks/task_e_68fc4a8548dc8330b7a4908b71cd4f34