### PR TITLE
Add English landing page and language switch button

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>JQ::Lite - Modern JSON operations for legacy servers</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
+  </style>
+</head>
+<body class="bg-slate-950 text-slate-100 font-[Inter]">
+  <header class="sticky top-0 z-50 border-b border-white/10 bg-slate-950/80 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
+      <a href="#top" class="text-2xl font-bold tracking-tight text-white">JQ::Lite</a>
+      <nav class="hidden items-center space-x-8 text-sm font-medium text-slate-300 md:flex">
+        <a href="#features" class="transition hover:text-white">Features</a>
+        <a href="#workflow" class="transition hover:text-white">Workflow</a>
+        <a href="#usecases" class="transition hover:text-white">Use cases</a>
+        <a href="#install" class="transition hover:text-white">Install</a>
+        <a href="#contact" class="rounded-full border border-white/20 px-4 py-2 transition hover:border-white hover:text-white">Contact</a>
+        <a href="index.html" class="rounded-full border border-white/20 px-4 py-2 text-slate-100 transition hover:border-white hover:text-white">日本語</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="top" class="relative">
+    <div class="absolute inset-0 -z-10 overflow-hidden">
+      <div class="pointer-events-none absolute left-1/2 top-0 h-[420px] w-[800px] -translate-x-1/2 rounded-full bg-cyan-500/30 blur-[120px]"></div>
+      <div class="pointer-events-none absolute bottom-0 right-0 h-[300px] w-[400px] translate-x-1/3 translate-y-1/4 rounded-full bg-blue-700/20 blur-[120px]"></div>
+    </div>
+
+    <!-- Hero -->
+    <section class="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-24 pt-20 md:flex-row md:items-center">
+      <div class="md:w-3/5">
+        <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/90">LEGACY FRIENDLY</span>
+        <h1 class="mt-6 text-4xl font-bold leading-tight text-white md:text-5xl">
+          Modernize your JSON workflows<br class="hidden md:block" />without abandoning your current stack.
+        </h1>
+        <p class="mt-6 text-lg text-slate-300 md:text-xl">
+          JQ::Lite is a lightweight JSON query &amp; editing tool written in pure Perl.<br class="hidden md:block" />It accelerates data operations even in tightly governed environments and networks with strict controls.
+        </p>
+        <div class="mt-10 flex flex-col gap-3 sm:flex-row">
+          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-cyan-500 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/30 transition hover:-translate-y-0.5 hover:bg-cyan-400">
+            View on GitHub
+            <span aria-hidden="true">→</span>
+          </a>
+          <a href="#install" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">
+            Install now
+          </a>
+          <a href="#quickstart" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">
+            Quickstart guide
+          </a>
+        </div>
+        <dl class="mt-12 grid gap-6 text-sm text-slate-300 sm:grid-cols-3">
+          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <dt class="text-xs uppercase tracking-wider text-slate-400">Supported Perl</dt>
+            <dd class="mt-1 text-2xl font-semibold text-white">5.14+</dd>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <dt class="text-xs uppercase tracking-wider text-slate-400">Extra dependencies</dt>
+            <dd class="mt-1 text-2xl font-semibold text-white">None</dd>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <dt class="text-xs uppercase tracking-wider text-slate-400">CLI &amp; module</dt>
+            <dd class="mt-1 text-2xl font-semibold text-white">Both available</dd>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-white/5 p-4 sm:col-span-3 lg:col-span-1">
+            <dt class="text-xs uppercase tracking-wider text-slate-400">Community support</dt>
+            <dd class="mt-1 text-sm font-medium text-slate-200">Continuously improved through Issues and Pull Requests</dd>
+          </div>
+        </dl>
+      </div>
+      <div class="md:w-2/5">
+        <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-xl shadow-black/30">
+          <div class="absolute inset-x-0 top-0 h-12 bg-gradient-to-b from-cyan-500/20 to-transparent"></div>
+          <div class="relative text-xs">
+            <div class="flex items-center gap-2 pb-4 text-[0.7rem] uppercase tracking-[0.2em] text-slate-400">JSON Playground</div>
+            <pre class="overflow-x-auto whitespace-pre-wrap rounded-2xl bg-black/60 p-4 text-[13px] leading-relaxed text-green-200">
+$ perl -MJQ::Lite -E 'say jq(q|.users[]| => { users => [ { name => "Alice" }, { name => "Bob" } ] })'
+{"name":"Alice"}
+{"name":"Bob"}
+
+$ jq-lite users.json '.stats | {active, lastSync}'
+{
+  "active": true,
+  "lastSync": "2025-03-12T09:44:00"
+}
+            </pre>
+          </div>
+          <p class="mt-6 text-sm text-slate-300">
+            Keep the familiar jq syntax while deploying on restricted servers. JQ::Lite works smoothly with audit trails and permission control in daily operations.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Quickstart for newcomers -->
+    <section id="quickstart" class="mx-auto max-w-6xl px-6 pb-24">
+      <div class="grid gap-10 rounded-3xl border border-white/10 bg-white/5 p-10 lg:grid-cols-2">
+        <div class="space-y-6">
+          <span class="inline-flex rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/70">For Beginners</span>
+          <h2 class="text-3xl font-semibold text-white">Command line newcomers welcome</h2>
+          <p class="text-sm leading-relaxed text-slate-300">
+            Worried about GitHub or CPAN? Our starter kit bundles the files and steps you need. Download, copy, and experience JSON processing in under three minutes.
+          </p>
+          <ul class="space-y-3 text-sm text-slate-200">
+            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">A</span><div><span class="font-semibold text-white">No account required</span><p class="mt-1 text-slate-300">Grab the installer directly without signing in to GitHub.</p></div></li>
+            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">B</span><div><span class="font-semibold text-white">Works without admin rights</span><p class="mt-1 text-slate-300">Place it in your home directory—no permission ticket needed.</p></div></li>
+            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">C</span><div><span class="font-semibold text-white">Sample data included</span><p class="mt-1 text-slate-300">Use <code>users.json</code> to try filters immediately.</p></div></li>
+          </ul>
+        </div>
+        <div class="space-y-6">
+          <div class="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-lg shadow-cyan-500/10">
+            <h3 class="text-lg font-semibold text-white">Starter kit in 3 steps</h3>
+            <ol class="mt-4 space-y-4 text-sm text-slate-200">
+              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-sm font-semibold text-cyan-100">STEP 1</span><div><p class="font-semibold text-white">Download the installer</p><p class="mt-1 text-slate-300">Save <code>install.sh</code> with the button below—right click and "Save link as" works too.</p><div class="mt-3"><a href="install.sh" download class="inline-flex items-center gap-2 rounded-full bg-cyan-500 px-5 py-2 text-xs font-semibold text-slate-950 transition hover:-translate-y-0.5 hover:bg-cyan-400">Download installer (.sh)</a></div></div></li>
+              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-sm font-semibold text-cyan-100">STEP 2</span><div><p class="font-semibold text-white">Run the command</p><p class="mt-1 text-slate-300">In your terminal, type <code>bash install.sh</code>. A prompt guides you through the destination folder.</p></div></li>
+              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-sm font-semibold text-cyan-100">STEP 3</span><div><p class="font-semibold text-white">Verify the setup</p><p class="mt-1 text-slate-300">Run <code>./jq-lite users.json '.users[0]'</code> to confirm everything works.</p></div></li>
+            </ol>
+          </div>
+          <div class="rounded-3xl border border-white/10 bg-white/5 p-6">
+            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Environment tips</h3>
+            <div class="mt-4 grid gap-4 text-sm text-slate-200 sm:grid-cols-2">
+              <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                <h4 class="text-base font-semibold text-white">macOS / Linux</h4>
+                <p class="mt-1 text-slate-300">Go to the folder where you saved the file and run <code>bash install.sh</code>. Guidance is shown for adding <code>~/bin</code> to your PATH.</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                <h4 class="text-base font-semibold text-white">Windows + WSL</h4>
+                <p class="mt-1 text-slate-300">Copy it into your WSL home directory and execute. If you only have PowerShell, contact us for a zip-based flow.</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4 sm:col-span-2">
+                <h4 class="text-base font-semibold text-white">Offline environments</h4>
+                <p class="mt-1 text-slate-300">Bring <code>install.sh</code> and <code>bin/jq-lite</code> via USB. We also provide a PDF guide for internal distribution.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Enterprise Logos -->
+    <section class="mx-auto max-w-6xl px-6 pb-16">
+      <div class="rounded-3xl border border-white/5 bg-white/5 px-6 py-8">
+        <p class="text-center text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Possible Use Cases</p>
+        <div class="mt-6 grid grid-cols-2 items-center gap-6 text-center text-sm font-semibold text-slate-400 md:grid-cols-4">
+          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">Finance (imagined)</span>
+          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">Manufacturing (imagined)</span>
+          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">Telecom (imagined)</span>
+          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">Public sector (imagined)</span>
+        </div>
+        <p class="mt-4 text-center text-xs text-slate-400">* Real-world case studies are welcome—share your experience with the community!</p>
+      </div>
+    </section>
+
+    <!-- Features -->
+    <section id="features" class="mx-auto max-w-6xl px-6 pb-24">
+      <div class="flex flex-col gap-6 text-center">
+        <span class="mx-auto inline-flex rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/90">Why JQ::Lite?</span>
+        <h2 class="text-3xl font-bold text-white md:text-4xl">Built for constrained environments</h2>
+        <p class="text-lg text-slate-300">
+          Legacy servers, isolated networks, strict corporate rules—JQ::Lite is designed for teams that cannot simply replace their infrastructure.
+        </p>
+      </div>
+      <div class="mt-14 grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🧬</div>
+          <h3 class="mt-6 text-xl font-semibold text-white">Single-file pure Perl</h3>
+          <p class="mt-3 text-sm leading-relaxed text-slate-300">No additional CPAN modules or build steps required. Drop it into the environment and go.</p>
+        </article>
+        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">⚡</div>
+          <h3 class="mt-6 text-xl font-semibold text-white">Lightweight &amp; fast</h3>
+          <p class="mt-3 text-sm leading-relaxed text-slate-300">Minimal implementation keeps performance steady even with limited CPU or memory.</p>
+        </article>
+        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🛡️</div>
+          <h3 class="mt-6 text-xl font-semibold text-white">Dependency-free and secure</h3>
+          <p class="mt-3 text-sm leading-relaxed text-slate-300">No compilation, no extra binaries. Friendly to environments with strict security policies.</p>
+        </article>
+        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🧰</div>
+          <h3 class="mt-6 text-xl font-semibold text-white">CLI and module ready</h3>
+          <p class="mt-3 text-sm leading-relaxed text-slate-300">Integrates naturally with existing Perl or shell scripts for flexible workflows.</p>
+        </article>
+        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🔍</div>
+          <h3 class="mt-6 text-xl font-semibold text-white">jq-compatible syntax</h3>
+          <p class="mt-3 text-sm leading-relaxed text-slate-300">Learn once, apply everywhere. Reuse your jq knowledge immediately.</p>
+        </article>
+        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">📦</div>
+          <h3 class="mt-6 text-xl font-semibold text-white">Great for text handling</h3>
+          <p class="mt-3 text-sm leading-relaxed text-slate-300">Streamline logs, API responses, or CI/CD reports with one compact tool.</p>
+        </article>
+      </div>
+    </section>
+
+    <!-- Enterprise Features -->
+    <section class="mx-auto max-w-6xl px-6 pb-24">
+      <div class="grid gap-10 rounded-3xl border border-white/10 bg-slate-950/60 p-10 lg:grid-cols-2">
+        <div class="space-y-6">
+          <span class="inline-flex rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/90">Enterprise Ready</span>
+          <h2 class="text-3xl font-semibold text-white">Governance essentials out of the box</h2>
+          <p class="text-sm leading-relaxed text-slate-300">
+            Build operations aligned with compliance and audit requirements. JQ::Lite connects with internal tools so you can show value right after rollout.
+          </p>
+          <ul class="space-y-4 text-sm text-slate-200">
+            <li class="flex items-start gap-3">
+              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">S</span>
+              <div>
+                <h3 class="text-base font-semibold text-white">Security audit logs</h3>
+                <p class="mt-1 text-slate-300">Send events to syslog or your internal platform to track every change.</p>
+              </div>
+            </li>
+            <li class="flex items-start gap-3">
+              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">G</span>
+              <div>
+                <h3 class="text-base font-semibold text-white">Governance controls</h3>
+                <p class="mt-1 text-slate-300">Separate roles and provide curated filter templates that match internal policies.</p>
+              </div>
+            </li>
+            <li class="flex items-start gap-3">
+              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">I</span>
+              <div>
+                <h3 class="text-base font-semibold text-white">Incident readiness</h3>
+                <p class="mt-1 text-slate-300">Format JSON logs instantly during outages and shorten recovery with playbooks.</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div class="rounded-3xl border border-white/10 bg-white/5 p-8">
+          <h3 class="text-lg font-semibold text-white">Questions to cover while evaluating</h3>
+          <dl class="mt-6 grid gap-6 text-sm text-slate-200 sm:grid-cols-2">
+            <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+              <dt class="text-xs uppercase tracking-[0.3em] text-slate-400">Fit with operations</dt>
+              <dd class="mt-2 text-sm text-slate-200">Can you plug it into existing scripts and runbooks without disruption?</dd>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+              <dt class="text-xs uppercase tracking-[0.3em] text-slate-400">Policy alignment</dt>
+              <dd class="mt-2 text-sm text-slate-200">Design operating rules that satisfy security and audit requirements.</dd>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4 sm:col-span-2">
+              <dt class="text-xs uppercase tracking-[0.3em] text-slate-400">Continuous improvement</dt>
+              <dd class="mt-2 text-sm text-slate-200">Leverage Issues and discussions to grow the tool with the community.</dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    </section>
+
+    <!-- Workflow -->
+    <section id="workflow" class="mx-auto max-w-6xl px-6 pb-24">
+      <div class="grid gap-12 rounded-3xl border border-white/10 bg-white/5 p-10 md:grid-cols-2">
+        <div>
+          <h2 class="text-3xl font-semibold text-white">From setup to day-to-day use</h2>
+          <p class="mt-4 text-sm leading-relaxed text-slate-300">JQ::Lite helps operations teams who cannot spare time for complex environments. Automate JSON processing with just three steps.</p>
+          <ul class="mt-8 space-y-6 text-sm text-slate-200">
+            <li class="flex items-start gap-4">
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-base font-semibold text-cyan-200">1</span>
+              <div>
+                <h3 class="text-lg font-semibold text-white">Deploy the files</h3>
+                <p class="mt-2 text-slate-300">Install from CPAN with <code>cpanm</code> or place the single file on your server.</p>
+              </div>
+            </li>
+            <li class="flex items-start gap-4">
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-base font-semibold text-cyan-200">2</span>
+              <div>
+                <h3 class="text-lg font-semibold text-white">Write filters</h3>
+                <p class="mt-2 text-slate-300">Use jq-style expressions to extract and transform JSON. Reuse the knowledge you already have.</p>
+              </div>
+            </li>
+            <li class="flex items-start gap-4">
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-base font-semibold text-cyan-200">3</span>
+              <div>
+                <h3 class="text-lg font-semibold text-white">Integrate with scripts</h3>
+                <p class="mt-2 text-slate-300">Require it as a Perl module or pipe data through the CLI—both work seamlessly.</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div class="rounded-3xl border border-white/10 bg-slate-950/60 p-6">
+          <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Config Snapshot</h3>
+          <pre class="mt-4 overflow-x-auto rounded-2xl bg-black/60 p-4 text-[13px] leading-relaxed text-slate-100">
+# Extract specific users
+$ jq-lite users.json '.users[] | select(.role == "admin") | {name, last_login}'
+
+# Use from a Perl script
+use JQ::Lite qw/jq/;
+my $json = decode_json($raw);
+my $admins = jq('.users[] | select(.role == "admin")', $json);
+          </pre>
+          <p class="mt-6 text-sm text-slate-300">By minimizing setup friction, even isolated networks can keep operations simple and secure.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Use Cases -->
+    <section id="usecases" class="mx-auto max-w-6xl px-6 pb-24">
+      <div class="rounded-3xl border border-white/10 bg-white/5 p-10">
+        <div class="text-center">
+          <h2 class="text-3xl font-semibold text-white">Use cases that blend into daily ops</h2>
+          <p class="mt-3 text-lg text-slate-300">Smart JSON handling brings a smoother rhythm to maintenance work.</p>
+        </div>
+        <div class="mt-10 grid gap-8 md:grid-cols-2">
+          <div class="rounded-2xl border border-white/10 bg-slate-950/50 p-6">
+            <h3 class="text-lg font-semibold text-white">Operations inside closed networks</h3>
+            <p class="mt-3 text-sm text-slate-300">Automate formatting and validation of JSON config files even when external binaries are forbidden.</p>
+            <ul class="mt-4 space-y-2 text-sm text-slate-300">
+              <li>・Validate diffs without a CI server</li>
+              <li>・Check JSON integrity before backups</li>
+            </ul>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-slate-950/50 p-6">
+            <h3 class="text-lg font-semibold text-white">Legacy modernization projects</h3>
+            <p class="mt-3 text-sm text-slate-300">Shift towards JSON-based workflows while keeping existing Perl scripts alive.</p>
+            <ul class="mt-4 space-y-2 text-sm text-slate-300">
+              <li>・Format API responses for older systems</li>
+              <li>・Convert logs to JSON for visualization platforms</li>
+            </ul>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-slate-950/50 p-6">
+            <h3 class="text-lg font-semibold text-white">CI/CD report aggregation</h3>
+            <p class="mt-3 text-sm text-slate-300">Process build logs and test results to send concise summaries to Slack or email.</p>
+            <ul class="mt-4 space-y-2 text-sm text-slate-300">
+              <li>・Embed jq-lite into batch jobs</li>
+              <li>・Run Perl scripts straight from GitHub Actions</li>
+            </ul>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-slate-950/50 p-6">
+            <h3 class="text-lg font-semibold text-white">Monitoring &amp; alert automation</h3>
+            <p class="mt-3 text-sm text-slate-300">Shape JSON outputs from monitoring tools and notify only when thresholds matter.</p>
+            <ul class="mt-4 space-y-2 text-sm text-slate-300">
+              <li>・Summarize server resource JSON reports</li>
+              <li>・Interoperate with existing shell scripts</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Testimonials -->
+    <section class="mx-auto max-w-6xl px-6 pb-24">
+      <div class="grid gap-8 md:grid-cols-3">
+        <article class="flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-slate-950/60 p-6">
+          <div>
+            <p class="text-sm leading-relaxed text-slate-200">“We are collecting success stories. Please share your insights and tips when you adopt JQ::Lite.”</p>
+          </div>
+          <footer class="mt-6 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">From the community</footer>
+        </article>
+        <article class="flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-slate-950/60 p-6">
+          <div>
+            <p class="text-sm leading-relaxed text-slate-200">“Blog posts or OSS repositories describing how you use JQ::Lite in business are a huge encouragement.”</p>
+          </div>
+          <footer class="mt-6 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">From the maintainers</footer>
+        </article>
+        <article class="flex h-full flex-col justify-between rounded-3xl border border-white/10 bg-slate-950/60 p-6">
+          <div>
+            <p class="text-sm leading-relaxed text-slate-200">“We do not have full visibility into deployments yet, so feedback through the form or Issues is greatly appreciated.”</p>
+          </div>
+          <footer class="mt-6 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Project team</footer>
+        </article>
+      </div>
+    </section>
+
+    <!-- Installation -->
+    <section id="install" class="mx-auto max-w-6xl px-6 pb-24">
+      <div class="rounded-3xl border border-white/10 bg-gradient-to-br from-cyan-500/20 via-slate-950 to-slate-950 p-10">
+        <div class="flex flex-col gap-10 lg:flex-row lg:items-center">
+          <div class="lg:w-2/5">
+            <span class="inline-flex rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/80">Install</span>
+            <h2 class="mt-4 text-3xl font-semibold text-white">Deploy in minutes</h2>
+            <p class="mt-3 text-sm text-slate-200">Even on-prem servers with heavy restrictions can be ready in three minutes. Reuse the same setup for CI/CD or cron batches.</p>
+            <div class="mt-6 flex flex-wrap gap-3 text-xs text-slate-200">
+              <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1"><span class="text-lg">✅</span> Perl 5.14+</span>
+              <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1"><span class="text-lg">✅</span> Zero external deps</span>
+              <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1"><span class="text-lg">✅</span> Single binary</span>
+            </div>
+          </div>
+          <div class="lg:w-3/5">
+            <pre class="h-full min-h-[280px] overflow-x-auto rounded-3xl border border-white/10 bg-black/70 p-6 text-[13px] leading-relaxed text-green-200">
+# Install from CPAN
+cpanm JQ::Lite
+
+# Install as a regular user
+curl -fsSL https://raw.githubusercontent.com/kawamurashingo/JQ-Lite/main/install.sh | bash
+
+# JSON transformation example
+jq-lite users.json '.users | map(select(.active)) | length'
+            </pre>
+            <div class="mt-6 grid gap-4 text-sm text-slate-200 lg:grid-cols-2">
+              <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                <h3 class="text-base font-semibold text-white">Want a click-through experience?</h3>
+                <p class="mt-2 text-slate-300">If you are unsure about running the installer, download <a href="install.sh" class="text-cyan-300 underline-offset-4 transition hover:text-cyan-200 hover:underline">install.sh</a> and share it by email together with our PDF guide.</p>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
+                <h3 class="text-base font-semibold text-white">Easy team rollout</h3>
+                <p class="mt-2 text-slate-300">The installer suggests target locations automatically. Prepare a shared folder with jq-lite and teammates can simply unzip &amp; double-click.</p>
+              </div>
+            </div>
+            <div class="mt-6 text-right text-sm">
+              <a href="https://github.com/kawamurashingo/JQ-Lite" class="text-cyan-300 underline-offset-4 transition hover:text-cyan-200 hover:underline">Browse the source on GitHub →</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA -->
+    <section class="mx-auto max-w-6xl px-6 pb-24">
+      <div class="flex flex-col gap-10 rounded-3xl border border-white/10 bg-white/5 p-10 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 class="text-3xl font-semibold text-white">Make JSON maintenance effortless.</h2>
+          <p class="mt-3 text-sm text-slate-300">Automate JSON validation and transformation while keeping your current assets intact. Upgrade without downtime.</p>
+        </div>
+        <div class="flex flex-col gap-3 sm:flex-row">
+          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-cyan-500 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/30 transition hover:-translate-y-0.5 hover:bg-cyan-400">Read the docs</a>
+          <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">Talk to us</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- Contact -->
+  <section id="contact" class="border-t border-white/10 bg-slate-950/90">
+    <div class="mx-auto flex max-w-6xl flex-col items-center gap-8 px-6 py-16 text-center">
+      <h2 class="text-3xl font-semibold text-white">Reach out for feedback or rollout support</h2>
+      <p class="max-w-2xl text-sm leading-relaxed text-slate-300">Questions about legacy constraints or proof-of-concept ideas? We would love to hear from you.</p>
+      <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-8 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">Send us an email</a>
+    </div>
+  </section>
+
+  <footer class="border-t border-white/10 bg-slate-950/95 py-8 text-center text-xs text-slate-500">
+    © 2025 JQ::Lite Project — Built with ❤️ in Perl
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         <a href="#usecases" class="transition hover:text-white">利用シーン</a>
         <a href="#install" class="transition hover:text-white">導入</a>
         <a href="#contact" class="rounded-full border border-white/20 px-4 py-2 transition hover:border-white hover:text-white">問い合わせ</a>
+        <a href="index-en.html" class="rounded-full border border-white/20 px-4 py-2 text-slate-100 transition hover:border-white hover:text-white">English</a>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- add an English version of the landing page covering the same sections as the Japanese site
- link the Japanese and English pages with a simple language toggle button in the navigation bar

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68fd6541aa908320b3ce8da5474cb0d2