### PR TITLE
Refresh marketing pages with gradient theme

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -7,10 +7,34 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
+
+    body {
+      background-color: #070313;
+      background-image:
+        radial-gradient(120% 80% at 0% -20%, rgba(168, 85, 247, 0.25), transparent),
+        radial-gradient(120% 80% at 100% 0%, rgba(236, 72, 153, 0.2), transparent),
+        linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.98));
+      color-scheme: dark;
+    }
+
+    .gradient-border {
+      position: relative;
+      isolation: isolate;
+    }
+
+    .gradient-border::before {
+      content: "";
+      position: absolute;
+      inset: -1px;
+      z-index: -1;
+      border-radius: inherit;
+      background: linear-gradient(135deg, rgba(168, 85, 247, 0.5), rgba(236, 72, 153, 0.3));
+      opacity: 0.8;
+    }
   </style>
 </head>
-<body class="bg-slate-950 text-slate-100 font-[Inter]">
-  <header class="sticky top-0 z-50 border-b border-white/10 bg-slate-950/80 backdrop-blur">
+<body class="relative min-h-screen text-slate-100 font-[Inter]">
+  <header class="sticky top-0 z-50 border-b border-white/10 bg-slate-900/70 backdrop-blur">
     <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
       <a href="#top" class="text-2xl font-bold tracking-tight text-white">JQ::Lite</a>
       <nav class="hidden items-center space-x-8 text-sm font-medium text-slate-300 md:flex">
@@ -18,7 +42,7 @@
         <a href="#workflow" class="transition hover:text-white">Workflow</a>
         <a href="#usecases" class="transition hover:text-white">Use cases</a>
         <a href="#install" class="transition hover:text-white">Install</a>
-        <a href="#contact" class="rounded-full border border-white/20 px-4 py-2 transition hover:border-white hover:text-white">Contact</a>
+        <a href="#contact" class="rounded-full border border-fuchsia-400/40 px-4 py-2 transition hover:border-fuchsia-200 hover:text-white">Contact</a>
         <a href="index.html" class="rounded-full border border-white/20 px-4 py-2 text-slate-100 transition hover:border-white hover:text-white">日本語</a>
       </nav>
     </div>
@@ -26,57 +50,57 @@
 
   <main id="top" class="relative">
     <div class="absolute inset-0 -z-10 overflow-hidden">
-      <div class="pointer-events-none absolute left-1/2 top-0 h-[420px] w-[800px] -translate-x-1/2 rounded-full bg-cyan-500/30 blur-[120px]"></div>
-      <div class="pointer-events-none absolute bottom-0 right-0 h-[300px] w-[400px] translate-x-1/3 translate-y-1/4 rounded-full bg-blue-700/20 blur-[120px]"></div>
+      <div class="pointer-events-none absolute left-1/2 top-[-10%] h-[520px] w-[960px] -translate-x-1/2 rounded-full bg-fuchsia-500/20 blur-[140px]"></div>
+      <div class="pointer-events-none absolute bottom-0 right-0 h-[360px] w-[460px] translate-x-1/3 translate-y-1/4 rounded-full bg-indigo-500/20 blur-[140px]"></div>
     </div>
 
     <!-- Hero -->
-    <section class="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-24 pt-20 md:flex-row md:items-center">
+    <section class="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-24 pt-24 md:flex-row md:items-center">
       <div class="md:w-3/5">
-        <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/90">LEGACY FRIENDLY</span>
+        <span class="inline-flex items-center gap-2 rounded-full border border-fuchsia-400/50 bg-fuchsia-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-fuchsia-200">LEGACY FRIENDLY</span>
         <h1 class="mt-6 text-4xl font-bold leading-tight text-white md:text-5xl">
           Modernize your JSON workflows<br class="hidden md:block" />without abandoning your current stack.
         </h1>
-        <p class="mt-6 text-lg text-slate-300 md:text-xl">
+        <p class="mt-6 text-lg leading-relaxed text-slate-200 md:text-xl">
           JQ::Lite is a lightweight JSON query &amp; editing tool written in pure Perl.<br class="hidden md:block" />It accelerates data operations even in tightly governed environments and networks with strict controls.
         </p>
         <div class="mt-10 flex flex-col gap-3 sm:flex-row">
-          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-cyan-500 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/30 transition hover:-translate-y-0.5 hover:bg-cyan-400">
+          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-fuchsia-400 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-fuchsia-500/40 transition hover:-translate-y-0.5 hover:bg-fuchsia-300">
             View on GitHub
             <span aria-hidden="true">→</span>
           </a>
-          <a href="#install" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">
+          <a href="#install" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/30 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">
             Install now
           </a>
-          <a href="#quickstart" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">
+          <a href="#quickstart" class="inline-flex items-center justify-center gap-2 rounded-full border border-fuchsia-400/50 px-7 py-3 text-sm font-semibold text-fuchsia-100 transition hover:border-fuchsia-200 hover:-translate-y-0.5">
             Quickstart guide
           </a>
         </div>
         <dl class="mt-12 grid gap-6 text-sm text-slate-300 sm:grid-cols-3">
-          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div class="gradient-border rounded-2xl border border-white/10 bg-slate-950/60 p-4">
             <dt class="text-xs uppercase tracking-wider text-slate-400">Supported Perl</dt>
             <dd class="mt-1 text-2xl font-semibold text-white">5.14+</dd>
           </div>
-          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div class="gradient-border rounded-2xl border border-white/10 bg-slate-950/60 p-4">
             <dt class="text-xs uppercase tracking-wider text-slate-400">Extra dependencies</dt>
             <dd class="mt-1 text-2xl font-semibold text-white">None</dd>
           </div>
-          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div class="gradient-border rounded-2xl border border-white/10 bg-slate-950/60 p-4">
             <dt class="text-xs uppercase tracking-wider text-slate-400">CLI &amp; module</dt>
             <dd class="mt-1 text-2xl font-semibold text-white">Both available</dd>
           </div>
-          <div class="rounded-2xl border border-white/10 bg-white/5 p-4 sm:col-span-3 lg:col-span-1">
+          <div class="gradient-border rounded-2xl border border-white/10 bg-slate-950/60 p-4 sm:col-span-3 lg:col-span-1">
             <dt class="text-xs uppercase tracking-wider text-slate-400">Community support</dt>
             <dd class="mt-1 text-sm font-medium text-slate-200">Continuously improved through Issues and Pull Requests</dd>
           </div>
         </dl>
       </div>
       <div class="md:w-2/5">
-        <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-xl shadow-black/30">
-          <div class="absolute inset-x-0 top-0 h-12 bg-gradient-to-b from-cyan-500/20 to-transparent"></div>
+        <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-xl shadow-fuchsia-900/40">
+          <div class="absolute inset-x-0 top-0 h-12 bg-gradient-to-b from-fuchsia-500/20 to-transparent"></div>
           <div class="relative text-xs">
             <div class="flex items-center gap-2 pb-4 text-[0.7rem] uppercase tracking-[0.2em] text-slate-400">JSON Playground</div>
-            <pre class="overflow-x-auto whitespace-pre-wrap rounded-2xl bg-black/60 p-4 text-[13px] leading-relaxed text-green-200">
+            <pre class="overflow-x-auto whitespace-pre-wrap rounded-2xl border border-white/10 bg-black/60 p-4 text-[13px] leading-relaxed text-emerald-200">
 $ perl -MJQ::Lite -E 'say jq(q|.users[]| => { users => [ { name => "Alice" }, { name => "Bob" } ] })'
 {"name":"Alice"}
 {"name":"Bob"}
@@ -97,30 +121,30 @@ $ jq-lite users.json '.stats | {active, lastSync}'
 
     <!-- Quickstart for newcomers -->
     <section id="quickstart" class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="grid gap-10 rounded-3xl border border-white/10 bg-white/5 p-10 lg:grid-cols-2">
+      <div class="grid gap-10 rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/30 lg:grid-cols-2">
         <div class="space-y-6">
-          <span class="inline-flex rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/70">For Beginners</span>
+          <span class="inline-flex rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-fuchsia-100">For Beginners</span>
           <h2 class="text-3xl font-semibold text-white">Command line newcomers welcome</h2>
           <p class="text-sm leading-relaxed text-slate-300">
             Worried about GitHub or CPAN? Our starter kit bundles the files and steps you need. Download, copy, and experience JSON processing in under three minutes.
           </p>
           <ul class="space-y-3 text-sm text-slate-200">
-            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">A</span><div><span class="font-semibold text-white">No account required</span><p class="mt-1 text-slate-300">Grab the installer directly without signing in to GitHub.</p></div></li>
-            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">B</span><div><span class="font-semibold text-white">Works without admin rights</span><p class="mt-1 text-slate-300">Place it in your home directory—no permission ticket needed.</p></div></li>
-            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">C</span><div><span class="font-semibold text-white">Sample data included</span><p class="mt-1 text-slate-300">Use <code>users.json</code> to try filters immediately.</p></div></li>
+            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">A</span><div><span class="font-semibold text-white">No account required</span><p class="mt-1 text-slate-300">Grab the installer directly without signing in to GitHub.</p></div></li>
+            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">B</span><div><span class="font-semibold text-white">Works without admin rights</span><p class="mt-1 text-slate-300">Place it in your home directory—no permission ticket needed.</p></div></li>
+            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">C</span><div><span class="font-semibold text-white">Sample data included</span><p class="mt-1 text-slate-300">Use <code>users.json</code> to try filters immediately.</p></div></li>
           </ul>
         </div>
         <div class="space-y-6">
-          <div class="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-lg shadow-cyan-500/10">
+          <div class="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-lg shadow-fuchsia-900/20">
             <h3 class="text-lg font-semibold text-white">Starter kit in 3 steps</h3>
             <ol class="mt-4 space-y-4 text-sm text-slate-200">
-              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-sm font-semibold text-cyan-100">STEP 1</span><div><p class="font-semibold text-white">Download the installer</p><p class="mt-1 text-slate-300">Save <code>install.sh</code> with the button below—right click and "Save link as" works too.</p><div class="mt-3"><a href="install.sh" download class="inline-flex items-center gap-2 rounded-full bg-cyan-500 px-5 py-2 text-xs font-semibold text-slate-950 transition hover:-translate-y-0.5 hover:bg-cyan-400">Download installer (.sh)</a></div></div></li>
-              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-sm font-semibold text-cyan-100">STEP 2</span><div><p class="font-semibold text-white">Run the command</p><p class="mt-1 text-slate-300">In your terminal, type <code>bash install.sh</code>. A prompt guides you through the destination folder.</p></div></li>
-              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-sm font-semibold text-cyan-100">STEP 3</span><div><p class="font-semibold text-white">Verify the setup</p><p class="mt-1 text-slate-300">Run <code>./jq-lite users.json '.users[0]'</code> to confirm everything works.</p></div></li>
+              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-sm font-semibold text-fuchsia-100">STEP 1</span><div><p class="font-semibold text-white">Download the installer</p><p class="mt-1 text-slate-300">Save <code>install.sh</code> with the button below—right click and "Save link as" works too.</p><div class="mt-3"><a href="install.sh" download class="inline-flex items-center gap-2 rounded-full bg-fuchsia-400 px-5 py-2 text-xs font-semibold text-slate-950 transition hover:-translate-y-0.5 hover:bg-fuchsia-300">Download installer (.sh)</a></div></div></li>
+              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-sm font-semibold text-fuchsia-100">STEP 2</span><div><p class="font-semibold text-white">Run the command</p><p class="mt-1 text-slate-300">In your terminal, type <code>bash install.sh</code>. A prompt guides you through the destination folder.</p></div></li>
+              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-sm font-semibold text-fuchsia-100">STEP 3</span><div><p class="font-semibold text-white">Verify the setup</p><p class="mt-1 text-slate-300">Run <code>./jq-lite users.json '.users[0]'</code> to confirm everything works.</p></div></li>
             </ol>
           </div>
-          <div class="rounded-3xl border border-white/10 bg-white/5 p-6">
-            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">Environment tips</h3>
+          <div class="rounded-3xl border border-white/10 bg-slate-950/60 p-6">
+            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-fuchsia-200">Environment tips</h3>
             <div class="mt-4 grid gap-4 text-sm text-slate-200 sm:grid-cols-2">
               <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
                 <h4 class="text-base font-semibold text-white">macOS / Linux</h4>
@@ -142,13 +166,13 @@ $ jq-lite users.json '.stats | {active, lastSync}'
 
     <!-- Enterprise Logos -->
     <section class="mx-auto max-w-6xl px-6 pb-16">
-      <div class="rounded-3xl border border-white/5 bg-white/5 px-6 py-8">
-        <p class="text-center text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">Possible Use Cases</p>
-        <div class="mt-6 grid grid-cols-2 items-center gap-6 text-center text-sm font-semibold text-slate-400 md:grid-cols-4">
-          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">Finance (imagined)</span>
-          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">Manufacturing (imagined)</span>
-          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">Telecom (imagined)</span>
-          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">Public sector (imagined)</span>
+      <div class="rounded-3xl border border-white/10 bg-slate-900/80 px-6 py-8 shadow-lg shadow-fuchsia-900/30">
+        <p class="text-center text-xs font-semibold uppercase tracking-[0.4em] text-fuchsia-200">Possible Use Cases</p>
+        <div class="mt-6 grid grid-cols-2 items-center gap-6 text-center text-sm font-semibold text-slate-200 md:grid-cols-4">
+          <span class="rounded-full border border-fuchsia-400/40 bg-slate-950/60 px-4 py-2">Finance (imagined)</span>
+          <span class="rounded-full border border-fuchsia-400/40 bg-slate-950/60 px-4 py-2">Manufacturing (imagined)</span>
+          <span class="rounded-full border border-fuchsia-400/40 bg-slate-950/60 px-4 py-2">Telecom (imagined)</span>
+          <span class="rounded-full border border-fuchsia-400/40 bg-slate-950/60 px-4 py-2">Public sector (imagined)</span>
         </div>
         <p class="mt-4 text-center text-xs text-slate-400">* Real-world case studies are welcome—share your experience with the community!</p>
       </div>
@@ -157,40 +181,40 @@ $ jq-lite users.json '.stats | {active, lastSync}'
     <!-- Features -->
     <section id="features" class="mx-auto max-w-6xl px-6 pb-24">
       <div class="flex flex-col gap-6 text-center">
-        <span class="mx-auto inline-flex rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/90">Why JQ::Lite?</span>
+        <span class="mx-auto inline-flex rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-fuchsia-100">Why JQ::Lite?</span>
         <h2 class="text-3xl font-bold text-white md:text-4xl">Built for constrained environments</h2>
         <p class="text-lg text-slate-300">
           Legacy servers, isolated networks, strict corporate rules—JQ::Lite is designed for teams that cannot simply replace their infrastructure.
         </p>
       </div>
       <div class="mt-14 grid gap-8 md:grid-cols-2 xl:grid-cols-3">
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🧬</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">🧬</div>
           <h3 class="mt-6 text-xl font-semibold text-white">Single-file pure Perl</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">No additional CPAN modules or build steps required. Drop it into the environment and go.</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">⚡</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">⚡</div>
           <h3 class="mt-6 text-xl font-semibold text-white">Lightweight &amp; fast</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">Minimal implementation keeps performance steady even with limited CPU or memory.</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🛡️</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">🛡️</div>
           <h3 class="mt-6 text-xl font-semibold text-white">Dependency-free and secure</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">No compilation, no extra binaries. Friendly to environments with strict security policies.</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🧰</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">🧰</div>
           <h3 class="mt-6 text-xl font-semibold text-white">CLI and module ready</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">Integrates naturally with existing Perl or shell scripts for flexible workflows.</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🔍</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">🔍</div>
           <h3 class="mt-6 text-xl font-semibold text-white">jq-compatible syntax</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">Learn once, apply everywhere. Reuse your jq knowledge immediately.</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">📦</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">📦</div>
           <h3 class="mt-6 text-xl font-semibold text-white">Great for text handling</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">Streamline logs, API responses, or CI/CD reports with one compact tool.</p>
         </article>
@@ -199,30 +223,30 @@ $ jq-lite users.json '.stats | {active, lastSync}'
 
     <!-- Enterprise Features -->
     <section class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="grid gap-10 rounded-3xl border border-white/10 bg-slate-950/60 p-10 lg:grid-cols-2">
+      <div class="grid gap-10 rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/30 lg:grid-cols-2">
         <div class="space-y-6">
-          <span class="inline-flex rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/90">Enterprise Ready</span>
+          <span class="inline-flex rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-fuchsia-100">Enterprise Ready</span>
           <h2 class="text-3xl font-semibold text-white">Governance essentials out of the box</h2>
           <p class="text-sm leading-relaxed text-slate-300">
             Build operations aligned with compliance and audit requirements. JQ::Lite connects with internal tools so you can show value right after rollout.
           </p>
           <ul class="space-y-4 text-sm text-slate-200">
             <li class="flex items-start gap-3">
-              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">S</span>
+              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">S</span>
               <div>
                 <h3 class="text-base font-semibold text-white">Security audit logs</h3>
                 <p class="mt-1 text-slate-300">Send events to syslog or your internal platform to track every change.</p>
               </div>
             </li>
             <li class="flex items-start gap-3">
-              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">G</span>
+              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">G</span>
               <div>
                 <h3 class="text-base font-semibold text-white">Governance controls</h3>
                 <p class="mt-1 text-slate-300">Separate roles and provide curated filter templates that match internal policies.</p>
               </div>
             </li>
             <li class="flex items-start gap-3">
-              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">I</span>
+              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">I</span>
               <div>
                 <h3 class="text-base font-semibold text-white">Incident readiness</h3>
                 <p class="mt-1 text-slate-300">Format JSON logs instantly during outages and shorten recovery with playbooks.</p>
@@ -230,7 +254,7 @@ $ jq-lite users.json '.stats | {active, lastSync}'
             </li>
           </ul>
         </div>
-        <div class="rounded-3xl border border-white/10 bg-white/5 p-8">
+        <div class="rounded-3xl border border-white/10 bg-slate-950/60 p-8">
           <h3 class="text-lg font-semibold text-white">Questions to cover while evaluating</h3>
           <dl class="mt-6 grid gap-6 text-sm text-slate-200 sm:grid-cols-2">
             <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
@@ -252,27 +276,27 @@ $ jq-lite users.json '.stats | {active, lastSync}'
 
     <!-- Workflow -->
     <section id="workflow" class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="grid gap-12 rounded-3xl border border-white/10 bg-white/5 p-10 md:grid-cols-2">
+      <div class="grid gap-12 rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/30 md:grid-cols-2">
         <div>
           <h2 class="text-3xl font-semibold text-white">From setup to day-to-day use</h2>
           <p class="mt-4 text-sm leading-relaxed text-slate-300">JQ::Lite helps operations teams who cannot spare time for complex environments. Automate JSON processing with just three steps.</p>
           <ul class="mt-8 space-y-6 text-sm text-slate-200">
             <li class="flex items-start gap-4">
-              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-base font-semibold text-cyan-200">1</span>
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-base font-semibold text-fuchsia-100">1</span>
               <div>
                 <h3 class="text-lg font-semibold text-white">Deploy the files</h3>
                 <p class="mt-2 text-slate-300">Install from CPAN with <code>cpanm</code> or place the single file on your server.</p>
               </div>
             </li>
             <li class="flex items-start gap-4">
-              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-base font-semibold text-cyan-200">2</span>
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-base font-semibold text-fuchsia-100">2</span>
               <div>
                 <h3 class="text-lg font-semibold text-white">Write filters</h3>
                 <p class="mt-2 text-slate-300">Use jq-style expressions to extract and transform JSON. Reuse the knowledge you already have.</p>
               </div>
             </li>
             <li class="flex items-start gap-4">
-              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-base font-semibold text-cyan-200">3</span>
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-base font-semibold text-fuchsia-100">3</span>
               <div>
                 <h3 class="text-lg font-semibold text-white">Integrate with scripts</h3>
                 <p class="mt-2 text-slate-300">Require it as a Perl module or pipe data through the CLI—both work seamlessly.</p>
@@ -298,7 +322,7 @@ my $admins = jq('.users[] | select(.role == "admin")', $json);
 
     <!-- Use Cases -->
     <section id="usecases" class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="rounded-3xl border border-white/10 bg-white/5 p-10">
+      <div class="rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/20">
         <div class="text-center">
           <h2 class="text-3xl font-semibold text-white">Use cases that blend into daily ops</h2>
           <p class="mt-3 text-lg text-slate-300">Smart JSON handling brings a smoother rhythm to maintenance work.</p>
@@ -366,7 +390,7 @@ my $admins = jq('.users[] | select(.role == "admin")', $json);
 
     <!-- Installation -->
     <section id="install" class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="rounded-3xl border border-white/10 bg-gradient-to-br from-cyan-500/20 via-slate-950 to-slate-950 p-10">
+      <div class="rounded-3xl border border-white/10 bg-gradient-to-br from-fuchsia-500/20 via-slate-950 to-slate-950 p-10">
         <div class="flex flex-col gap-10 lg:flex-row lg:items-center">
           <div class="lg:w-2/5">
             <span class="inline-flex rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/80">Install</span>
@@ -392,7 +416,7 @@ jq-lite users.json '.users | map(select(.active)) | length'
             <div class="mt-6 grid gap-4 text-sm text-slate-200 lg:grid-cols-2">
               <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
                 <h3 class="text-base font-semibold text-white">Want a click-through experience?</h3>
-                <p class="mt-2 text-slate-300">If you are unsure about running the installer, download <a href="install.sh" class="text-cyan-300 underline-offset-4 transition hover:text-cyan-200 hover:underline">install.sh</a> and share it by email together with our PDF guide.</p>
+                <p class="mt-2 text-slate-300">If you are unsure about running the installer, download <a href="install.sh" class="text-fuchsia-300 underline-offset-4 transition hover:text-fuchsia-200 hover:underline">install.sh</a> and share it by email together with our PDF guide.</p>
               </div>
               <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
                 <h3 class="text-base font-semibold text-white">Easy team rollout</h3>
@@ -400,7 +424,7 @@ jq-lite users.json '.users | map(select(.active)) | length'
               </div>
             </div>
             <div class="mt-6 text-right text-sm">
-              <a href="https://github.com/kawamurashingo/JQ-Lite" class="text-cyan-300 underline-offset-4 transition hover:text-cyan-200 hover:underline">Browse the source on GitHub →</a>
+              <a href="https://github.com/kawamurashingo/JQ-Lite" class="text-fuchsia-300 underline-offset-4 transition hover:text-fuchsia-200 hover:underline">Browse the source on GitHub →</a>
             </div>
           </div>
         </div>
@@ -409,14 +433,14 @@ jq-lite users.json '.users | map(select(.active)) | length'
 
     <!-- CTA -->
     <section class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="flex flex-col gap-10 rounded-3xl border border-white/10 bg-white/5 p-10 md:flex-row md:items-center md:justify-between">
+      <div class="flex flex-col gap-10 rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/30 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 class="text-3xl font-semibold text-white">Make JSON maintenance effortless.</h2>
           <p class="mt-3 text-sm text-slate-300">Automate JSON validation and transformation while keeping your current assets intact. Upgrade without downtime.</p>
         </div>
         <div class="flex flex-col gap-3 sm:flex-row">
-          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-cyan-500 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/30 transition hover:-translate-y-0.5 hover:bg-cyan-400">Read the docs</a>
-          <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">Talk to us</a>
+          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-fuchsia-400 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-fuchsia-500/40 transition hover:-translate-y-0.5 hover:bg-fuchsia-300">Read the docs</a>
+          <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-fuchsia-400/40 px-7 py-3 text-sm font-semibold text-white transition hover:border-fuchsia-200 hover:-translate-y-0.5">Talk to us</a>
         </div>
       </div>
     </section>
@@ -427,7 +451,7 @@ jq-lite users.json '.users | map(select(.active)) | length'
     <div class="mx-auto flex max-w-6xl flex-col items-center gap-8 px-6 py-16 text-center">
       <h2 class="text-3xl font-semibold text-white">Reach out for feedback or rollout support</h2>
       <p class="max-w-2xl text-sm leading-relaxed text-slate-300">Questions about legacy constraints or proof-of-concept ideas? We would love to hear from you.</p>
-      <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-8 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">Send us an email</a>
+      <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-fuchsia-400/40 px-8 py-3 text-sm font-semibold text-white transition hover:border-fuchsia-200 hover:-translate-y-0.5">Send us an email</a>
     </div>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -7,10 +7,34 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
+
+    body {
+      background-color: #070313;
+      background-image:
+        radial-gradient(120% 80% at 0% -20%, rgba(168, 85, 247, 0.25), transparent),
+        radial-gradient(120% 80% at 100% 0%, rgba(236, 72, 153, 0.2), transparent),
+        linear-gradient(180deg, rgba(15, 23, 42, 0.95), rgba(2, 6, 23, 0.98));
+      color-scheme: dark;
+    }
+
+    .gradient-border {
+      position: relative;
+      isolation: isolate;
+    }
+
+    .gradient-border::before {
+      content: "";
+      position: absolute;
+      inset: -1px;
+      z-index: -1;
+      border-radius: inherit;
+      background: linear-gradient(135deg, rgba(168, 85, 247, 0.5), rgba(236, 72, 153, 0.3));
+      opacity: 0.8;
+    }
   </style>
 </head>
-<body class="bg-slate-950 text-slate-100 font-[Inter]">
-  <header class="sticky top-0 z-50 border-b border-white/10 bg-slate-950/80 backdrop-blur">
+<body class="relative min-h-screen text-slate-100 font-[Inter]">
+  <header class="sticky top-0 z-50 border-b border-white/10 bg-slate-900/70 backdrop-blur">
     <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-5">
       <a href="#top" class="text-2xl font-bold tracking-tight text-white">JQ::Lite</a>
       <nav class="hidden items-center space-x-8 text-sm font-medium text-slate-300 md:flex">
@@ -18,7 +42,7 @@
         <a href="#workflow" class="transition hover:text-white">動作イメージ</a>
         <a href="#usecases" class="transition hover:text-white">利用シーン</a>
         <a href="#install" class="transition hover:text-white">導入</a>
-        <a href="#contact" class="rounded-full border border-white/20 px-4 py-2 transition hover:border-white hover:text-white">問い合わせ</a>
+        <a href="#contact" class="rounded-full border border-fuchsia-400/40 px-4 py-2 transition hover:border-fuchsia-200 hover:text-white">問い合わせ</a>
         <a href="index-en.html" class="rounded-full border border-white/20 px-4 py-2 text-slate-100 transition hover:border-white hover:text-white">English</a>
       </nav>
     </div>
@@ -26,57 +50,57 @@
 
   <main id="top" class="relative">
     <div class="absolute inset-0 -z-10 overflow-hidden">
-      <div class="pointer-events-none absolute left-1/2 top-0 h-[420px] w-[800px] -translate-x-1/2 rounded-full bg-cyan-500/30 blur-[120px]"></div>
-      <div class="pointer-events-none absolute bottom-0 right-0 h-[300px] w-[400px] translate-x-1/3 translate-y-1/4 rounded-full bg-blue-700/20 blur-[120px]"></div>
+      <div class="pointer-events-none absolute left-1/2 top-[-10%] h-[520px] w-[960px] -translate-x-1/2 rounded-full bg-fuchsia-500/20 blur-[140px]"></div>
+      <div class="pointer-events-none absolute bottom-0 right-0 h-[360px] w-[460px] translate-x-1/3 translate-y-1/4 rounded-full bg-indigo-500/20 blur-[140px]"></div>
     </div>
 
     <!-- Hero -->
-    <section class="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-24 pt-20 md:flex-row md:items-center">
+    <section class="mx-auto flex max-w-6xl flex-col gap-12 px-6 pb-24 pt-24 md:flex-row md:items-center">
       <div class="md:w-3/5">
-        <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/90">LEGACY FRIENDLY</span>
+        <span class="inline-flex items-center gap-2 rounded-full border border-fuchsia-400/50 bg-fuchsia-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-fuchsia-200">LEGACY FRIENDLY</span>
         <h1 class="mt-6 text-4xl font-bold leading-tight text-white md:text-5xl">
           既存資産を守りながら、<br class="hidden md:block" />JSON運用を近代化。
         </h1>
-        <p class="mt-6 text-lg text-slate-300 md:text-xl">
+        <p class="mt-6 text-lg leading-relaxed text-slate-200 md:text-xl">
           JQ::Lite は純Perlで動く軽量JSONクエリ＆編集ツール。<br class="hidden md:block" />制約の多い環境でも、厳格なガバナンスや監査要件に応えながらデータ活用を加速させます。
         </p>
         <div class="mt-10 flex flex-col gap-3 sm:flex-row">
-          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-cyan-500 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/30 transition hover:-translate-y-0.5 hover:bg-cyan-400">
+          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-fuchsia-400 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-fuchsia-500/40 transition hover:-translate-y-0.5 hover:bg-fuchsia-300">
             GitHubで見る
             <span aria-hidden="true">→</span>
           </a>
-          <a href="#install" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">
+          <a href="#install" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/30 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">
             すぐ導入する
           </a>
-          <a href="#quickstart" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">
+          <a href="#quickstart" class="inline-flex items-center justify-center gap-2 rounded-full border border-fuchsia-400/50 px-7 py-3 text-sm font-semibold text-fuchsia-100 transition hover:border-fuchsia-200 hover:-translate-y-0.5">
             はじめてガイド
           </a>
         </div>
         <dl class="mt-12 grid gap-6 text-sm text-slate-300 sm:grid-cols-3">
-          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div class="gradient-border rounded-2xl border border-white/10 bg-slate-950/60 p-4">
             <dt class="text-xs uppercase tracking-wider text-slate-400">対応Perlバージョン</dt>
             <dd class="mt-1 text-2xl font-semibold text-white">5.14+</dd>
           </div>
-          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div class="gradient-border rounded-2xl border border-white/10 bg-slate-950/60 p-4">
             <dt class="text-xs uppercase tracking-wider text-slate-400">追加依存</dt>
             <dd class="mt-1 text-2xl font-semibold text-white">なし</dd>
           </div>
-          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <div class="gradient-border rounded-2xl border border-white/10 bg-slate-950/60 p-4">
             <dt class="text-xs uppercase tracking-wider text-slate-400">CLI &amp; モジュール</dt>
             <dd class="mt-1 text-2xl font-semibold text-white">両対応</dd>
           </div>
-          <div class="rounded-2xl border border-white/10 bg-white/5 p-4 sm:col-span-3 lg:col-span-1">
+          <div class="gradient-border rounded-2xl border border-white/10 bg-slate-950/60 p-4 sm:col-span-3 lg:col-span-1">
             <dt class="text-xs uppercase tracking-wider text-slate-400">コミュニティサポート</dt>
             <dd class="mt-1 text-sm font-medium text-slate-200">Issue / Pull Request を通じて随時改善中</dd>
           </div>
         </dl>
       </div>
       <div class="md:w-2/5">
-        <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-xl shadow-black/30">
-          <div class="absolute inset-x-0 top-0 h-12 bg-gradient-to-b from-cyan-500/20 to-transparent"></div>
+        <div class="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/80 p-6 shadow-xl shadow-fuchsia-900/40">
+          <div class="absolute inset-x-0 top-0 h-12 bg-gradient-to-b from-fuchsia-500/20 to-transparent"></div>
           <div class="relative text-xs">
             <div class="flex items-center gap-2 pb-4 text-[0.7rem] uppercase tracking-[0.2em] text-slate-400">JSON Playground</div>
-            <pre class="overflow-x-auto whitespace-pre-wrap rounded-2xl bg-black/60 p-4 text-[13px] leading-relaxed text-green-200">
+            <pre class="overflow-x-auto whitespace-pre-wrap rounded-2xl border border-white/10 bg-black/60 p-4 text-[13px] leading-relaxed text-emerald-200">
 $ perl -MJQ::Lite -E 'say jq(q|.users[]| =&gt; { users =&gt; [ { name =&gt; "Alice" }, { name =&gt; "Bob" } ] })'
 {"name":"Alice"}
 {"name":"Bob"}
@@ -97,30 +121,30 @@ $ jq-lite users.json '.stats | {active, lastSync}'
 
     <!-- Quickstart for newcomers -->
     <section id="quickstart" class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="grid gap-10 rounded-3xl border border-white/10 bg-white/5 p-10 lg:grid-cols-2">
+      <div class="grid gap-10 rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/30 lg:grid-cols-2">
         <div class="space-y-6">
-          <span class="inline-flex rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/70">For Beginners</span>
+          <span class="inline-flex rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-fuchsia-100">For Beginners</span>
           <h2 class="text-3xl font-semibold text-white">コマンドラインが初めてでも大丈夫</h2>
           <p class="text-sm leading-relaxed text-slate-300">
             「GitHub や CPAN は難しそう…」という方のために、必要なファイルと手順をまとめたスターターキットをご用意しました。ダウンロードしてコピペするだけで、最短 3 分で JSON 処理を体験できます。
           </p>
           <ul class="space-y-3 text-sm text-slate-200">
-            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">A</span><div><span class="font-semibold text-white">アカウント登録不要</span><p class="mt-1 text-slate-300">GitHub にログインしなくても、ページから直接インストーラを取得できます。</p></div></li>
-            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">B</span><div><span class="font-semibold text-white">管理者権限なしで設置</span><p class="mt-1 text-slate-300">ホームディレクトリに配置できるので、権限申請の手間を抑えられます。</p></div></li>
-            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">C</span><div><span class="font-semibold text-white">サンプルデータ付き</span><p class="mt-1 text-slate-300">users.json でフィルタの書き方をそのまま試せます。</p></div></li>
+            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">A</span><div><span class="font-semibold text-white">アカウント登録不要</span><p class="mt-1 text-slate-300">GitHub にログインしなくても、ページから直接インストーラを取得できます。</p></div></li>
+            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">B</span><div><span class="font-semibold text-white">管理者権限なしで設置</span><p class="mt-1 text-slate-300">ホームディレクトリに配置できるので、権限申請の手間を抑えられます。</p></div></li>
+            <li class="flex items-start gap-3"><span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">C</span><div><span class="font-semibold text-white">サンプルデータ付き</span><p class="mt-1 text-slate-300">users.json でフィルタの書き方をそのまま試せます。</p></div></li>
           </ul>
         </div>
         <div class="space-y-6">
-          <div class="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-lg shadow-cyan-500/10">
+          <div class="rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-lg shadow-fuchsia-900/20">
             <h3 class="text-lg font-semibold text-white">スターターキット 3 ステップ</h3>
             <ol class="mt-4 space-y-4 text-sm text-slate-200">
-              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-sm font-semibold text-cyan-100">STEP 1</span><div><p class="font-semibold text-white">インストーラをダウンロード</p><p class="mt-1 text-slate-300">下のボタンから <code>install.sh</code> を保存します。右クリックして「リンク先を保存」を選ぶだけで OK。</p><div class="mt-3"><a href="install.sh" download class="inline-flex items-center gap-2 rounded-full bg-cyan-500 px-5 py-2 text-xs font-semibold text-slate-950 transition hover:-translate-y-0.5 hover:bg-cyan-400">インストーラを保存 (.sh)</a></div></div></li>
-              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-sm font-semibold text-cyan-100">STEP 2</span><div><p class="font-semibold text-white">コマンドをそのまま実行</p><p class="mt-1 text-slate-300">ターミナルで <code>bash install.sh</code> と打つだけ。保存先のディレクトリを選ぶ案内が表示されます。</p></div></li>
-              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-sm font-semibold text-cyan-100">STEP 3</span><div><p class="font-semibold text-white">セットアップを確認</p><p class="mt-1 text-slate-300"><code>./jq-lite users.json '.users[0]'</code> を試すと、すぐに JSON 抽出結果が確認できます。</p></div></li>
+              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-sm font-semibold text-fuchsia-100">STEP 1</span><div><p class="font-semibold text-white">インストーラをダウンロード</p><p class="mt-1 text-slate-300">下のボタンから <code>install.sh</code> を保存します。右クリックして「リンク先を保存」を選ぶだけで OK。</p><div class="mt-3"><a href="install.sh" download class="inline-flex items-center gap-2 rounded-full bg-fuchsia-400 px-5 py-2 text-xs font-semibold text-slate-950 transition hover:-translate-y-0.5 hover:bg-fuchsia-300">インストーラを保存 (.sh)</a></div></div></li>
+              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-sm font-semibold text-fuchsia-100">STEP 2</span><div><p class="font-semibold text-white">コマンドをそのまま実行</p><p class="mt-1 text-slate-300">ターミナルで <code>bash install.sh</code> と打つだけ。保存先のディレクトリを選ぶ案内が表示されます。</p></div></li>
+              <li class="flex items-start gap-4"><span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-sm font-semibold text-fuchsia-100">STEP 3</span><div><p class="font-semibold text-white">セットアップを確認</p><p class="mt-1 text-slate-300"><code>./jq-lite users.json '.users[0]'</code> を試すと、すぐに JSON 抽出結果が確認できます。</p></div></li>
             </ol>
           </div>
-          <div class="rounded-3xl border border-white/10 bg-white/5 p-6">
-            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">環境別ヒント</h3>
+          <div class="rounded-3xl border border-white/10 bg-slate-950/60 p-6">
+            <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-fuchsia-200">環境別ヒント</h3>
             <div class="mt-4 grid gap-4 text-sm text-slate-200 sm:grid-cols-2">
               <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
                 <h4 class="text-base font-semibold text-white">macOS / Linux</h4>
@@ -142,13 +166,13 @@ $ jq-lite users.json '.stats | {active, lastSync}'
 
     <!-- Enterprise Logos -->
     <section class="mx-auto max-w-6xl px-6 pb-16">
-      <div class="rounded-3xl border border-white/5 bg-white/5 px-6 py-8">
-        <p class="text-center text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">POSSIBLE USE CASES</p>
-        <div class="mt-6 grid grid-cols-2 items-center gap-6 text-center text-sm font-semibold text-slate-400 md:grid-cols-4">
-          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">金融（想定）</span>
-          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">製造（想定）</span>
-          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">通信（想定）</span>
-          <span class="rounded-full border border-white/10 bg-slate-950/60 px-4 py-2">公共（想定）</span>
+      <div class="rounded-3xl border border-white/10 bg-slate-900/80 px-6 py-8 shadow-lg shadow-fuchsia-900/30">
+        <p class="text-center text-xs font-semibold uppercase tracking-[0.4em] text-fuchsia-200">POSSIBLE USE CASES</p>
+        <div class="mt-6 grid grid-cols-2 items-center gap-6 text-center text-sm font-semibold text-slate-200 md:grid-cols-4">
+          <span class="rounded-full border border-fuchsia-400/40 bg-slate-950/60 px-4 py-2">金融（想定）</span>
+          <span class="rounded-full border border-fuchsia-400/40 bg-slate-950/60 px-4 py-2">製造（想定）</span>
+          <span class="rounded-full border border-fuchsia-400/40 bg-slate-950/60 px-4 py-2">通信（想定）</span>
+          <span class="rounded-full border border-fuchsia-400/40 bg-slate-950/60 px-4 py-2">公共（想定）</span>
         </div>
         <p class="mt-4 text-center text-xs text-slate-400">※ 実際の導入事例はコミュニティからのフィードバックをお待ちしています。</p>
       </div>
@@ -157,40 +181,40 @@ $ jq-lite users.json '.stats | {active, lastSync}'
     <!-- Features -->
     <section id="features" class="mx-auto max-w-6xl px-6 pb-24">
       <div class="flex flex-col gap-6 text-center">
-        <span class="mx-auto inline-flex rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/90">Why JQ::Lite?</span>
+        <span class="mx-auto inline-flex rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-fuchsia-100">Why JQ::Lite?</span>
         <h2 class="text-3xl font-bold text-white md:text-4xl">制約のある現場でこそ真価を発揮</h2>
         <p class="text-lg text-slate-300">
           レガシーサーバ、閉域網、厳格な社内ルール。JQ::Lite は、そんな「入れ替えできない」現場のために設計されています。
         </p>
       </div>
       <div class="mt-14 grid gap-8 md:grid-cols-2 xl:grid-cols-3">
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🧬</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">🧬</div>
           <h3 class="mt-6 text-xl font-semibold text-white">純Perlワンファイル構成</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">CPAN モジュールの追加も、ビルドも不要。環境にそのままドロップインできます。</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">⚡</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">⚡</div>
           <h3 class="mt-6 text-xl font-semibold text-white">軽量＆高速</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">ミニマルな実装で、制約された CPU / メモリ環境でも快適に動作します。</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🛡️</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">🛡️</div>
           <h3 class="mt-6 text-xl font-semibold text-white">依存ゼロで安全</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">コンパイル不要・追加バイナリ不要。セキュリティポリシーが厳しい現場でも安心です。</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🧰</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">🧰</div>
           <h3 class="mt-6 text-xl font-semibold text-white">CLI / モジュール両対応</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">既存の Perl スクリプトやシェルスクリプトに自然に組み込める柔軟性。</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">🔍</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">🔍</div>
           <h3 class="mt-6 text-xl font-semibold text-white">jq互換の直感操作</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">シンタックスは jq を踏襲。学習コストゼロで導入できます。</p>
         </article>
-        <article class="group h-full rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:-translate-y-1 hover:border-cyan-400/50 hover:bg-cyan-500/10">
-          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-cyan-500/20 text-2xl">📦</div>
+        <article class="group h-full rounded-3xl border border-white/10 bg-slate-950/60 p-6 transition hover:-translate-y-1 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full bg-fuchsia-500/15 text-2xl">📦</div>
           <h3 class="mt-6 text-xl font-semibold text-white">テキスト処理にも最適</h3>
           <p class="mt-3 text-sm leading-relaxed text-slate-300">ログ整形、APIレスポンス解析、CI/CD レポート作成など幅広いワークフローで活躍します。</p>
         </article>
@@ -199,30 +223,30 @@ $ jq-lite users.json '.stats | {active, lastSync}'
 
     <!-- Enterprise Features -->
     <section class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="grid gap-10 rounded-3xl border border-white/10 bg-slate-950/60 p-10 lg:grid-cols-2">
+      <div class="grid gap-10 rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/30 lg:grid-cols-2">
         <div class="space-y-6">
-          <span class="inline-flex rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-200/90">Enterprise Ready</span>
+          <span class="inline-flex rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-fuchsia-100">Enterprise Ready</span>
           <h2 class="text-3xl font-semibold text-white">導入に必要なガバナンスを標準装備</h2>
           <p class="text-sm leading-relaxed text-slate-300">
             コンプライアンスや監査要件に即したオペレーションを構築できます。社内ツールとの連携も容易で、導入後すぐに成果を可視化できます。
           </p>
           <ul class="space-y-4 text-sm text-slate-200">
             <li class="flex items-start gap-3">
-              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">S</span>
+              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">S</span>
               <div>
                 <h3 class="text-base font-semibold text-white">セキュリティ監査ログ</h3>
                 <p class="mt-1 text-slate-300">syslog など社内標準の監査基盤へ出力し、変更履歴を追跡可能。</p>
               </div>
             </li>
             <li class="flex items-start gap-3">
-              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">G</span>
+              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">G</span>
               <div>
                 <h3 class="text-base font-semibold text-white">ガバナンス統制</h3>
                 <p class="mt-1 text-slate-300">社内ポリシーに合わせて権限分離。ロールに応じたフィルタテンプレート提供が可能。</p>
               </div>
             </li>
             <li class="flex items-start gap-3">
-              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500/20 text-xs font-semibold text-cyan-100">I</span>
+              <span class="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-fuchsia-500/15 text-xs font-semibold text-fuchsia-100">I</span>
               <div>
                 <h3 class="text-base font-semibold text-white">インシデント対応力</h3>
                 <p class="mt-1 text-slate-300">障害時に JSON ログを即時整形。オペレーション手順書との連携で復旧時間を短縮。</p>
@@ -230,7 +254,7 @@ $ jq-lite users.json '.stats | {active, lastSync}'
             </li>
           </ul>
         </div>
-        <div class="rounded-3xl border border-white/10 bg-white/5 p-8">
+        <div class="rounded-3xl border border-white/10 bg-slate-950/60 p-8">
           <h3 class="text-lg font-semibold text-white">検討時のチェックポイント</h3>
           <dl class="mt-6 grid gap-6 text-sm text-slate-200 sm:grid-cols-2">
             <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
@@ -252,27 +276,27 @@ $ jq-lite users.json '.stats | {active, lastSync}'
 
     <!-- Workflow -->
     <section id="workflow" class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="grid gap-12 rounded-3xl border border-white/10 bg-white/5 p-10 md:grid-cols-2">
+      <div class="grid gap-12 rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/30 md:grid-cols-2">
         <div>
           <h2 class="text-3xl font-semibold text-white">導入から活用までの流れ</h2>
           <p class="mt-4 text-sm leading-relaxed text-slate-300">JQ::Lite は環境構築に時間をかけたくない運用チームの味方です。たった3ステップですぐに JSON 処理を自動化できます。</p>
           <ul class="mt-8 space-y-6 text-sm text-slate-200">
             <li class="flex items-start gap-4">
-              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-base font-semibold text-cyan-200">1</span>
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-base font-semibold text-fuchsia-100">1</span>
               <div>
                 <h3 class="text-lg font-semibold text-white">ファイルを設置</h3>
                 <p class="mt-2 text-slate-300">CPAN から cpanm で入れるか、単一ファイルを環境に配置するだけ。</p>
               </div>
             </li>
             <li class="flex items-start gap-4">
-              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-base font-semibold text-cyan-200">2</span>
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-base font-semibold text-fuchsia-100">2</span>
               <div>
                 <h3 class="text-lg font-semibold text-white">フィルタを書く</h3>
                 <p class="mt-2 text-slate-300">jq と同じ書き方で JSON を抽出・変換。既存のナレッジをそのまま活かせます。</p>
               </div>
             </li>
             <li class="flex items-start gap-4">
-              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-cyan-500/20 text-base font-semibold text-cyan-200">3</span>
+              <span class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-fuchsia-500/15 text-base font-semibold text-fuchsia-100">3</span>
               <div>
                 <h3 class="text-lg font-semibold text-white">スクリプトへ組み込む</h3>
                 <p class="mt-2 text-slate-300">Perl モジュールとして require しても、CLI としてパイプに流し込んでも OK。</p>
@@ -298,7 +322,7 @@ my $admins = jq('.users[] | select(.role == "admin")', $json);
 
     <!-- Use Cases -->
     <section id="usecases" class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="rounded-3xl border border-white/10 bg-white/5 p-10">
+      <div class="rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/20">
         <div class="text-center">
           <h2 class="text-3xl font-semibold text-white">現場の運用に溶け込むユースケース</h2>
           <p class="mt-3 text-lg text-slate-300">痒いところに手が届く JSON 処理で、日々の保守作業をスマートに。</p>
@@ -366,7 +390,7 @@ my $admins = jq('.users[] | select(.role == "admin")', $json);
 
     <!-- Installation -->
     <section id="install" class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="rounded-3xl border border-white/10 bg-gradient-to-br from-cyan-500/20 via-slate-950 to-slate-950 p-10">
+      <div class="rounded-3xl border border-white/10 bg-gradient-to-br from-fuchsia-500/20 via-slate-950 to-slate-950 p-10">
         <div class="flex flex-col gap-10 lg:flex-row lg:items-center">
           <div class="lg:w-2/5">
             <span class="inline-flex rounded-full border border-white/10 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-white/80">Install</span>
@@ -392,7 +416,7 @@ jq-lite users.json '.users | map(select(.active)) | length'
             <div class="mt-6 grid gap-4 text-sm text-slate-200 lg:grid-cols-2">
               <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
                 <h3 class="text-base font-semibold text-white">クリックだけで試したい方へ</h3>
-                <p class="mt-2 text-slate-300">インストーラの実行に不安がある場合は、<a href="install.sh" class="text-cyan-300 underline-offset-4 transition hover:text-cyan-200 hover:underline">install.sh</a> をメールで共有し、詳しい手順書（PDF）を同梱して展開できます。</p>
+                <p class="mt-2 text-slate-300">インストーラの実行に不安がある場合は、<a href="install.sh" class="text-fuchsia-300 underline-offset-4 transition hover:text-fuchsia-200 hover:underline">install.sh</a> をメールで共有し、詳しい手順書（PDF）を同梱して展開できます。</p>
               </div>
               <div class="rounded-2xl border border-white/10 bg-slate-950/60 p-4">
                 <h3 class="text-base font-semibold text-white">チーム展開も簡単</h3>
@@ -400,7 +424,7 @@ jq-lite users.json '.users | map(select(.active)) | length'
               </div>
             </div>
             <div class="mt-6 text-right text-sm">
-              <a href="https://github.com/kawamurashingo/JQ-Lite" class="text-cyan-300 underline-offset-4 transition hover:text-cyan-200 hover:underline">GitHubでソースを見る →</a>
+              <a href="https://github.com/kawamurashingo/JQ-Lite" class="text-fuchsia-300 underline-offset-4 transition hover:text-fuchsia-200 hover:underline">GitHubでソースを見る →</a>
             </div>
           </div>
         </div>
@@ -409,14 +433,14 @@ jq-lite users.json '.users | map(select(.active)) | length'
 
     <!-- CTA -->
     <section class="mx-auto max-w-6xl px-6 pb-24">
-      <div class="flex flex-col gap-10 rounded-3xl border border-white/10 bg-white/5 p-10 md:flex-row md:items-center md:justify-between">
+      <div class="flex flex-col gap-10 rounded-3xl border border-white/10 bg-slate-900/80 p-10 shadow-xl shadow-fuchsia-900/30 md:flex-row md:items-center md:justify-between">
         <div>
           <h2 class="text-3xl font-semibold text-white">チームのJSON整備を、もっと手軽に。</h2>
           <p class="mt-3 text-sm text-slate-300">既存資産を活かしたまま、JSON データの加工や検証を自動化。プロジェクトの稼働停止なしにアップグレードできます。</p>
         </div>
         <div class="flex flex-col gap-3 sm:flex-row">
-          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-cyan-500 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/30 transition hover:-translate-y-0.5 hover:bg-cyan-400">ドキュメントを見る</a>
-          <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-7 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">導入相談をする</a>
+          <a href="https://github.com/kawamurashingo/JQ-Lite" class="inline-flex items-center justify-center gap-2 rounded-full bg-fuchsia-400 px-7 py-3 text-sm font-semibold text-slate-950 shadow-lg shadow-fuchsia-500/40 transition hover:-translate-y-0.5 hover:bg-fuchsia-300">ドキュメントを見る</a>
+          <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-fuchsia-400/40 px-7 py-3 text-sm font-semibold text-white transition hover:border-fuchsia-200 hover:-translate-y-0.5">導入相談をする</a>
         </div>
       </div>
     </section>
@@ -427,7 +451,7 @@ jq-lite users.json '.users | map(select(.active)) | length'
     <div class="mx-auto flex max-w-6xl flex-col items-center gap-8 px-6 py-16 text-center">
       <h2 class="text-3xl font-semibold text-white">導入相談・フィードバックはこちら</h2>
       <p class="max-w-2xl text-sm leading-relaxed text-slate-300">レガシー環境特有の制約や PoC の相談など、お気軽にご連絡ください。</p>
-      <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-white/20 px-8 py-3 text-sm font-semibold text-white transition hover:border-white hover:-translate-y-0.5">メールで問い合わせる</a>
+      <a href="mailto:perl.jq.lite@gmail.com" class="inline-flex items-center justify-center gap-2 rounded-full border border-fuchsia-400/40 px-8 py-3 text-sm font-semibold text-white transition hover:border-fuchsia-200 hover:-translate-y-0.5">メールで問い合わせる</a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- restyle the Japanese and English landing pages with a fuchsia inspired gradient background and updated hero treatments
- align buttons, callouts, and badges to the new palette while adding subtle glow borders for feature metrics
- refresh quickstart, workflow, and CTA sections with consistent card styling and highlighted links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd66c1833c83208e5a9835c9fff340