### PR TITLE
Improve offline installer workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,23 @@ brew tap kawamurashingo/jq-lite
 brew install --HEAD jq-lite
 ```
 
-### 🐧 Portable (Linux/macOS)
+### 🐧 Portable installer (online → offline)
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/kawamurashingo/JQ-Lite/main/install.sh | bash
-```
+1. **On an internet-connected machine**
+   ```bash
+   ./download.sh
+   ```
+   *Use `-o /path/to/usb` to place the tarball somewhere else.*
 
-> Installs to `$HOME/.local/bin`.
-> Add to PATH if needed:
->
+2. **Transfer** `JQ-Lite-<version>.tar.gz` to the offline/target machine (USB, SCP, etc.).
+
+3. **On the target machine**
+   ```bash
+   ./install.sh /path/to/JQ-Lite-<version>.tar.gz
+   ```
+   *Use `-p /custom/prefix` to change the install location or `--skip-tests` to avoid running `make test`.*
+
+> The installer defaults to `$HOME/.local`. Add it to your PATH if needed:
 > ```bash
 > export PATH="$HOME/.local/bin:$PATH"
 > ```

--- a/download.sh
+++ b/download.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIST_NAME="JQ-Lite"
+OUT_DIR="."
+
+usage() {
+  cat <<USAGE
+Usage: $0 [-o <output-dir>]
+
+Downloads the latest ${DIST_NAME} release tarball from MetaCPAN into the
+specified directory (defaults to the current directory).
+
+Options:
+  -o <dir>   Directory where the tarball should be saved (default: current)
+  -h         Show this help message
+USAGE
+}
+
+while getopts ":o:h" opt; do
+  case "$opt" in
+    o)
+      OUT_DIR="$OPTARG"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    :)
+      echo "[ERROR] Option -$OPTARG requires an argument." >&2
+      usage >&2
+      exit 1
+      ;;
+    ?)
+      echo "[ERROR] Unknown option -$OPTARG" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [[ $# -gt 0 ]]; then
+  echo "[ERROR] Unexpected positional arguments: $*" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "[ERROR] curl is required to download the tarball." >&2
+  exit 1
+fi
+
+if [[ ! -d "$OUT_DIR" ]]; then
+  echo "[INFO] Creating output directory $OUT_DIR"
+  mkdir -p "$OUT_DIR"
+fi
+
+META_URL="https://fastapi.metacpan.org/v1/release/${DIST_NAME}?fields=download_url,version"
+
+echo "[INFO] Fetching latest version of $DIST_NAME from MetaCPAN..."
+RELEASE_JSON=$(curl -sSfL "$META_URL")
+DOWNLOAD_URL=$(printf '%s' "$RELEASE_JSON" | grep '"download_url"' | cut -d'"' -f4)
+VERSION=$(printf '%s' "$RELEASE_JSON" | grep '"version"' | head -n1 | cut -d'"' -f4)
+
+if [[ -z "$DOWNLOAD_URL" ]]; then
+  echo "[ERROR] Failed to resolve the download URL from MetaCPAN." >&2
+  exit 1
+fi
+
+TARBALL_NAME="${DIST_NAME}-${VERSION}.tar.gz"
+TARGET_PATH="${OUT_DIR%/}/$TARBALL_NAME"
+
+if [[ -f "$TARGET_PATH" ]]; then
+  echo "[WARN] $TARGET_PATH already exists. Overwriting..."
+  rm -f "$TARGET_PATH"
+fi
+
+echo "[INFO] Downloading $TARBALL_NAME..."
+curl -sSfL "$DOWNLOAD_URL" -o "$TARGET_PATH"
+
+echo
+cat <<EOM
+[INFO] Download complete.
+Copy $TARGET_PATH to your offline environment (e.g. via USB), then run:
+  ./install.sh $TARBALL_NAME
+from within the target machine.
+EOM

--- a/install.sh
+++ b/install.sh
@@ -1,38 +1,139 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-DIST_NAME="JQ-Lite"
+PREFIX="${PREFIX:-$HOME/.local}"
+RUN_TESTS=1
 
-echo "[INFO] Fetching latest version of $DIST_NAME from MetaCPAN..."
+usage() {
+  cat <<USAGE
+Usage: $0 [-p <prefix>] [--skip-tests] [<tarball>]
 
-TARBALL_URL=$(curl -s "https://fastapi.metacpan.org/v1/release/$DIST_NAME" | grep '"download_url"' | cut -d'"' -f4)
-if [[ -z "$TARBALL_URL" ]]; then
-  echo "[ERROR] Failed to fetch tarball URL from MetaCPAN."
+Installs JQ-Lite from a pre-downloaded tarball. If no tarball is
+specified, the latest JQ-Lite-*.tar.gz file in the current directory is
+used.
+
+Options:
+  -p <prefix>    Installation prefix (default: \$PREFIX (env) or \$HOME/.local)
+  --skip-tests   Skip make test
+  -h             Show this help message
+USAGE
+}
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -p)
+      if [[ -z "${2:-}" ]]; then
+        echo "[ERROR] -p requires a prefix argument." >&2
+        usage >&2
+        exit 1
+      fi
+      PREFIX="$2"
+      shift 2
+      ;;
+    --skip-tests)
+      RUN_TESTS=0
+      shift
+      ;;
+    -h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "[ERROR] Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ $# -gt 0 ]]; then
+  POSITIONAL+=("$@")
+fi
+
+if [[ ${#POSITIONAL[@]} -gt 1 ]]; then
+  echo "[ERROR] Too many positional arguments." >&2
+  usage >&2
   exit 1
 fi
 
-TAR=$(basename "$TARBALL_URL")
-DIST="${TAR%.tar.gz}"
+TARBALL="${POSITIONAL[0]:-}"
 
-echo "[INFO] Downloading $TAR..."
-curl -sLO "$TARBALL_URL"
+if [[ -z "$TARBALL" ]]; then
+  TARBALL=$(ls -t JQ-Lite-*.tar.gz 2>/dev/null | head -n1 || true)
+fi
 
-echo "[INFO] Extracting..."
-tar xzf "$TAR" 2>/dev/null
+if [[ -z "$TARBALL" ]]; then
+  echo "[ERROR] No JQ-Lite tarball found. Pass the tarball path as an argument or place it in this directory." >&2
+  exit 1
+fi
 
-echo "[INFO] Resetting timestamps to avoid future file errors..."
-find "$DIST" -exec touch {} + >/dev/null 2>&1
+if [[ ! -f "$TARBALL" ]]; then
+  echo "[ERROR] Tarball '$TARBALL' not found." >&2
+  exit 1
+fi
 
-cd "$DIST"
+for tool in tar perl make; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "[ERROR] Required tool '$tool' is not available." >&2
+    exit 1
+  fi
+done
 
-echo "[INFO] Installing..."
-perl Makefile.PL PREFIX=$HOME/.local >/dev/null
+if [[ $RUN_TESTS -eq 1 ]] && ! command -v prove >/dev/null 2>&1; then
+  echo "[WARN] 'prove' not found; tests will be skipped."
+  RUN_TESTS=0
+fi
+
+if command -v realpath >/dev/null 2>&1; then
+  TARBALL_ABS=$(realpath "$TARBALL")
+else
+  TARBALL_ABS=$(perl -MCwd=abs_path -e 'print abs_path(shift)' "$TARBALL")
+fi
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+cd "$WORK_DIR"
+
+DIST_DIR=$(tar tzf "$TARBALL_ABS" | head -n1 | cut -d'/' -f1)
+if [[ -z "$DIST_DIR" ]]; then
+  echo "[ERROR] Unable to determine distribution directory from $TARBALL." >&2
+  exit 1
+fi
+
+if [[ -d "$DIST_DIR" ]]; then
+  rm -rf "$DIST_DIR"
+fi
+
+echo "[INFO] Extracting $TARBALL..."
+tar xzf "$TARBALL_ABS"
+
+cd "$DIST_DIR"
+
+echo "[INFO] Installing to $PREFIX..."
+perl Makefile.PL PREFIX="$PREFIX" >/dev/null
 make
-make test
+
+if [[ $RUN_TESTS -eq 1 ]]; then
+  make test
+else
+  echo "[INFO] Skipping tests."
+fi
+
 make install
 
-echo ""
-echo "[INFO] Installation complete."
-echo "Make sure to add the following to your shell config:"
-echo '  export PATH="$HOME/.local/bin:$PATH"'
+echo
+cat <<EOM
+[INFO] Installation complete.
+Ensure the following is in your shell configuration:
+  export PATH="$PREFIX/bin:\$PATH"
+EOM


### PR DESCRIPTION
## Summary
- harden `download.sh` with argument parsing, safety checks, and clearer messaging for offline transfers
- extend `install.sh` with prefix selection, optional test execution, dependency checks, and safer extraction
- document the new online/offline portable installation workflow in the README

## Testing
- shellcheck download.sh install.sh *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fd6a116bcc83208006c90381249d08