### PR TITLE
Handle macOS extended header warnings in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -104,7 +104,12 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 
 cd "$WORK_DIR"
 
-DIST_DIR=$(tar tzf "$TARBALL_ABS" | head -n1 | cut -d'/' -f1)
+TAR_WARN_FLAGS=()
+if tar --version 2>/dev/null | grep -qi 'gnu tar'; then
+  TAR_WARN_FLAGS+=(--warning=no-unknown-keyword)
+fi
+
+DIST_DIR=$(tar "${TAR_WARN_FLAGS[@]}" tzf "$TARBALL_ABS" | head -n1 | cut -d'/' -f1)
 if [[ -z "$DIST_DIR" ]]; then
   echo "[ERROR] Unable to determine distribution directory from $TARBALL." >&2
   exit 1
@@ -115,7 +120,7 @@ if [[ -d "$DIST_DIR" ]]; then
 fi
 
 echo "[INFO] Extracting $TARBALL..."
-tar xzf "$TARBALL_ABS"
+tar "${TAR_WARN_FLAGS[@]}" xzf "$TARBALL_ABS"
 
 cd "$DIST_DIR"
 


### PR DESCRIPTION
## Summary
- detect GNU tar and add no-unknown-keyword warning suppression for extraction commands
- reuse the warning suppression flags for both tar listing and extraction steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd6d7194d88320a032d543b32789cf