### PR TITLE
Add landing page for JQ::Lite

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JQ::Lite — Lightweight jq in Pure Perl</title>
+  <link rel="icon" href="images/JQ_Lite_sm.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f172a;
+      --bg-alt: #111827;
+      --bg-card: rgba(15, 23, 42, 0.7);
+      --text: #e2e8f0;
+      --text-muted: #94a3b8;
+      --accent: #38bdf8;
+      --accent-strong: #0ea5e9;
+      --code-bg: rgba(15, 23, 42, 0.9);
+      font-size: clamp(15px, 1.2vw, 18px);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.2), transparent 40%),
+                  radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.2), transparent 35%),
+                  var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    header {
+      padding: clamp(2rem, 5vw, 5rem) clamp(1.5rem, 6vw, 6rem);
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+
+    header::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, rgba(14, 165, 233, 0.35), rgba(59, 130, 246, 0.25));
+      opacity: 0.65;
+      filter: blur(120px);
+      z-index: -1;
+    }
+
+    .logo {
+      width: clamp(96px, 18vw, 128px);
+      height: auto;
+      margin-bottom: clamp(1.5rem, 4vw, 3rem);
+      filter: drop-shadow(0 12px 24px rgba(8, 47, 73, 0.6));
+    }
+
+    h1 {
+      font-size: clamp(2.5rem, 5vw, 3.8rem);
+      margin-bottom: 1rem;
+      letter-spacing: -0.02em;
+      font-weight: 700;
+    }
+
+    p.lead {
+      font-size: clamp(1.1rem, 2.5vw, 1.45rem);
+      color: var(--text-muted);
+      max-width: 820px;
+      margin: 0 auto clamp(2rem, 4vw, 3rem);
+    }
+
+    .cta {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.85rem 1.6rem;
+      border-radius: 999px;
+      background: linear-gradient(120deg, var(--accent), var(--accent-strong));
+      color: #0f172a;
+      text-decoration: none;
+      font-weight: 600;
+      transition: transform 0.3s ease, box-shadow 0.3s ease;
+      box-shadow: 0 18px 34px rgba(56, 189, 248, 0.35);
+    }
+
+    .cta:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 24px 48px rgba(56, 189, 248, 0.45);
+    }
+
+    main {
+      width: min(1100px, 92vw);
+      margin: 0 auto clamp(4rem, 8vw, 6rem);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: clamp(3rem, 6vw, 4.5rem);
+    }
+
+    section {
+      background: var(--bg-card);
+      border: 1px solid rgba(148, 163, 184, 0.12);
+      border-radius: 22px;
+      padding: clamp(2rem, 4vw, 3rem);
+      box-shadow: 0 24px 42px rgba(15, 23, 42, 0.45);
+      backdrop-filter: blur(12px);
+    }
+
+    section h2 {
+      margin-top: 0;
+      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      margin-bottom: 1rem;
+    }
+
+    .grid {
+      display: grid;
+      gap: clamp(1.5rem, 3vw, 2.2rem);
+    }
+
+    .grid-3 {
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .card {
+      background: rgba(15, 23, 42, 0.6);
+      border-radius: 18px;
+      padding: 1.5rem;
+      border: 1px solid rgba(148, 163, 184, 0.16);
+      transition: border 0.3s ease, transform 0.3s ease;
+    }
+
+    .card:hover {
+      border-color: rgba(56, 189, 248, 0.55);
+      transform: translateY(-4px);
+    }
+
+    .card h3 {
+      margin-top: 0;
+      margin-bottom: 0.75rem;
+      font-size: 1.2rem;
+    }
+
+    code, pre {
+      font-family: 'Fira Code', monospace;
+      background: var(--code-bg);
+      color: #bae6fd;
+    }
+
+    pre {
+      margin: 1rem 0;
+      padding: 1rem 1.2rem;
+      border-radius: 14px;
+      overflow-x: auto;
+      border: 1px solid rgba(56, 189, 248, 0.18);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+    }
+
+    ul {
+      padding-left: 1.1rem;
+      margin: 0;
+      color: var(--text-muted);
+    }
+
+    li + li {
+      margin-top: 0.35rem;
+    }
+
+    .badges {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.8rem;
+      margin-bottom: clamp(2rem, 3vw, 2.5rem);
+    }
+
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.5rem 0.9rem;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.7);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      color: var(--text-muted);
+      font-size: 0.95rem;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2.5rem 1rem 3.5rem;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+    }
+
+    a {
+      color: var(--accent);
+    }
+
+    @media (max-width: 720px) {
+      header {
+        padding-top: 3.5rem;
+      }
+
+      .badges {
+        flex-direction: column;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <img src="images/JQ_Lite_sm.png" alt="JQ::Lite logo" class="logo">
+    <h1>JQ::Lite</h1>
+    <p class="lead">Pure Perlで実装された軽量な jq 互換エンジン。制約の多い環境でも JSON や YAML を自在にクエリし、変換できます。</p>
+    <div class="badges">
+      <span class="badge">🪶 Pure Perl</span>
+      <span class="badge">🔍 jq 互換フィルタ</span>
+      <span class="badge">💻 CLI & モジュール</span>
+      <span class="badge">🌐 オフライン対応</span>
+    </div>
+    <a class="cta" href="https://metacpan.org/release/JQ-Lite" target="_blank" rel="noopener">MetaCPANで見る →</a>
+  </header>
+
+  <main>
+    <section>
+      <h2>主な特徴</h2>
+      <div class="grid grid-3">
+        <div class="card">
+          <h3>🪶 純粋な Perl 実装</h3>
+          <p>XS や C コンパイル不要。Perl が動く環境なら、どこでも同じように使えます。レガシー環境や閉域網でもインストールは簡単です。</p>
+        </div>
+        <div class="card">
+          <h3>🔍 jq スタイルのクエリ</h3>
+          <p><code>.users[].name</code> や <code>select(.age &gt; 25)</code> といった jq そのままの記法。条件分岐やマップ処理など、複雑なフィルタも思いのまま。</p>
+        </div>
+        <div class="card">
+          <h3>🧰 CLI &amp; ライブラリ</h3>
+          <p>コマンドラインツール <code>jq-lite</code> としても、Perl モジュールとしても利用可能。スクリプトに組み込んで JSON 変換を自動化できます。</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>インストール</h2>
+      <div class="grid" style="gap: 2.2rem;">
+        <div class="card">
+          <h3>CPAN から</h3>
+          <pre><code>cpanm JQ::Lite</code></pre>
+          <p>最速で試すなら CPAN が便利。依存モジュールもまとめて解決します。</p>
+        </div>
+        <div class="card">
+          <h3>Homebrew (macOS)</h3>
+          <pre><code>brew tap kawamurashingo/jq-lite
+brew install --HEAD jq-lite</code></pre>
+          <p>macOS ユーザーは Homebrew からインストール可能。HEAD ビルドで最新の機能を体験できます。</p>
+        </div>
+        <div class="card">
+          <h3>ポータブルインストーラ</h3>
+          <pre><code>./download.sh [-v &lt;version&gt;] [-o /path/to/usb]
+./install.sh [-p &lt;prefix&gt;] [--skip-tests] path/to/JQ-Lite.tar.gz</code></pre>
+          <p>オンラインで取得してオフラインで展開。閉域環境でもセットアップできます。</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>使い方</h2>
+      <div class="grid" style="gap: 2.2rem;">
+        <div class="card">
+          <h3>Perl モジュールとして</h3>
+          <pre><code>use JQ::Lite;
+
+my $jq = JQ::Lite-&gt;new;
+my @names = $jq-&gt;run_query(
+  '{"users":[{"name":"Alice"}]}',
+  '.users[].name'
+);
+print join "\n", @names;</code></pre>
+        </div>
+        <div class="card">
+          <h3>CLI ツールとして</h3>
+          <pre><code>jq-lite '.users[].name' users.json
+jq-lite '.users[] | select(.age &gt; 25)' users.json
+jq-lite --yaml '.users[].name' users.yaml</code></pre>
+        </div>
+        <div class="card">
+          <h3>インタラクティブモード</h3>
+          <pre><code>jq-lite users.json</code></pre>
+          <p>入力ファイルを指定するだけで、フィルタを試しながら JSON を探索できます。</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>どんなときに便利？</h2>
+      <div class="grid grid-3">
+        <div class="card">
+          <h3>制約の厳しいサーバ</h3>
+          <p>コンパイラや root 権限がなくても導入可能。Perl が入っていればすぐに使えます。</p>
+        </div>
+        <div class="card">
+          <h3>CI/CD パイプライン</h3>
+          <p>追加バイナリなしで JSON を検査・変換。スクリプト内で完結するのでメンテもしやすい。</p>
+        </div>
+        <div class="card">
+          <h3>データ探索・変換</h3>
+          <p>jq に慣れたエンジニアにも違和感のない操作感。組み込みの 100+ 関数で複雑な処理もお手のもの。</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p>© 2024 JQ::Lite. Built with ❤️ in Perl.</p>
+    <p><a href="https://github.com/kawamurashingo/JQ-Lite" target="_blank" rel="noopener">GitHub</a> · <a href="https://metacpan.org/release/JQ-Lite" target="_blank" rel="noopener">MetaCPAN</a></p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a polished landing page `index.html` that highlights JQ::Lite features, installation options, and usage examples
- style the page with a dark, glassmorphism-inspired theme and responsive layout inspired by typetiny.toby.ink
- include quick links to MetaCPAN and GitHub along with key selling points badges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fde607c8e08320af1c57db30c51335