### PR TITLE
Remove MetaCPAN link from header CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,7 +410,6 @@
       <a href="#scenes">🎯 活用シーン</a>
       <a href="#contact">✉️ お問い合わせ</a>
     </nav>
-    <a class="cta" href="https://metacpan.org/release/JQ-Lite" target="_blank" rel="noopener">MetaCPANで見る →</a>
   </header>
 
   <main>


### PR DESCRIPTION
## Summary
- remove the MetaCPAN call-to-action link from the landing page header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fdf1a748f48320bcb32b18ac50867a