### PR TITLE
Center hero logo on landing pages

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -64,7 +64,8 @@
     .logo {
       width: clamp(190px, 30vw, 260px);
       height: auto;
-      margin-bottom: clamp(1.5rem, 4vw, 3rem);
+      display: block;
+      margin: 0 auto clamp(1.5rem, 4vw, 3rem);
       filter: drop-shadow(0 12px 24px rgba(8, 47, 73, 0.6));
     }
 

--- a/index.html
+++ b/index.html
@@ -64,7 +64,8 @@
     .logo {
       width: clamp(190px, 30vw, 260px);
       height: auto;
-      margin-bottom: clamp(1.5rem, 4vw, 3rem);
+      display: block;
+      margin: 0 auto clamp(1.5rem, 4vw, 3rem);
       filter: drop-shadow(0 12px 24px rgba(8, 47, 73, 0.6));
     }
 


### PR DESCRIPTION
## Summary
- center the hero logo on the Japanese and English landing pages by making the image a block element with automatic horizontal margins

## Testing
- visual inspection in local browser

------
https://chatgpt.com/codex/tasks/task_e_68fdf76b42588320b84320ccb657993c