### PR TITLE
Highlight Perl 5.14+ support on landing pages

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -440,6 +440,7 @@
       <span class="badge">🪶 Pure Perl</span>
       <span class="badge">🔍 jq-style filters</span>
       <span class="badge">💻 CLI &amp; module</span>
+      <span class="badge">✅ Supports Perl 5.14+</span>
       <span class="badge">🌐 Works offline</span>
     </div>
     <nav class="tab-nav" aria-label="Section tabs">

--- a/index.html
+++ b/index.html
@@ -440,6 +440,7 @@
       <span class="badge">🪶 Pure Perl</span>
       <span class="badge">🔍 jq 互換フィルタ</span>
       <span class="badge">💻 CLI & モジュール</span>
+      <span class="badge">✅ Perl 5.14+ 対応</span>
       <span class="badge">🌐 オフライン対応</span>
     </div>
     <nav class="tab-nav" aria-label="セクションタブ">


### PR DESCRIPTION
## Summary
- add a Perl 5.14+ compatibility badge to the Japanese landing page
- mirror the Perl 5.14+ badge on the English landing page

## Testing
- no automated tests were run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68fe0b5e57d88320ba7e8b5c539a77a9