### PR TITLE
Translate vision page headings to Japanese

### DIFF
--- a/vision.html
+++ b/vision.html
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JQ::Lite — ビジョン</title>
+  <link rel="icon" href="images/JQ_Lite_sm.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f172a;
+      --bg-alt: #111827;
+      --bg-card: rgba(15, 23, 42, 0.7);
+      --text: #e2e8f0;
+      --text-muted: #94a3b8;
+      --accent: #38bdf8;
+      --accent-strong: #0ea5e9;
+      --code-bg: rgba(15, 23, 42, 0.9);
+      font-size: clamp(15px, 1.2vw, 18px);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.2), transparent 40%),
+                  radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.2), transparent 35%),
+                  var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow-x: hidden;
+    }
+
+    header {
+      padding: clamp(2rem, 5vw, 5rem) clamp(1.5rem, 6vw, 6rem);
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .global-nav {
+      position: absolute;
+      top: clamp(1rem, 3vw, 2rem);
+      right: clamp(1.5rem, 5vw, 4rem);
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .global-nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.55rem 1.15rem;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 600;
+      transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    }
+
+    .global-nav a:hover,
+    .global-nav a:focus-visible {
+      border-color: rgba(56, 189, 248, 0.55);
+      box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+      transform: translateY(-2px);
+      outline: none;
+    }
+
+    header::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, rgba(14, 165, 233, 0.35), rgba(59, 130, 246, 0.25));
+      opacity: 0.65;
+      filter: blur(120px);
+      z-index: -1;
+    }
+
+    .logo {
+      width: clamp(190px, 30vw, 260px);
+      height: auto;
+      display: block;
+      margin: 0 auto clamp(1.5rem, 4vw, 3rem);
+      filter: drop-shadow(0 12px 24px rgba(8, 47, 73, 0.6));
+    }
+
+    h1 {
+      font-size: clamp(2.5rem, 5vw, 3.8rem);
+      margin-bottom: 1rem;
+      letter-spacing: -0.02em;
+      font-weight: 700;
+    }
+
+    p.lead {
+      font-size: clamp(1.1rem, 2.5vw, 1.45rem);
+      color: var(--text-muted);
+      max-width: 820px;
+      margin: 0 auto clamp(2rem, 4vw, 3rem);
+    }
+
+    .tab-nav {
+      display: inline-flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.8rem;
+      margin-bottom: clamp(2rem, 4vw, 3rem);
+    }
+
+    .tab-nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.65rem 1.3rem;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.65);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 600;
+      transition: border 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .tab-nav a:hover,
+    .tab-nav a:focus-visible {
+      border-color: rgba(56, 189, 248, 0.55);
+      box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+      transform: translateY(-2px);
+      outline: none;
+    }
+
+    @media (max-width: 720px) {
+      .global-nav {
+        position: static;
+        margin-bottom: 1.5rem;
+        gap: 0.6rem;
+      }
+    }
+
+    main {
+      width: min(1100px, 92vw);
+      margin: 0 auto clamp(4rem, 8vw, 6rem);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: clamp(3rem, 6vw, 4.5rem);
+    }
+
+    section {
+      background: var(--bg-card);
+      border: 1px solid rgba(148, 163, 184, 0.12);
+      border-radius: 22px;
+      padding: clamp(2rem, 4vw, 3rem);
+      box-shadow: 0 24px 42px rgba(15, 23, 42, 0.45);
+      backdrop-filter: blur(12px);
+    }
+
+    section h2 {
+      margin-top: 0;
+      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      margin-bottom: 1.2rem;
+    }
+
+    ul {
+      padding-left: 1.2rem;
+      margin: 1rem 0;
+      color: var(--text-muted);
+    }
+
+    li + li {
+      margin-top: 0.35rem;
+    }
+
+    p {
+      color: var(--text-muted);
+      margin: 0 0 1rem 0;
+    }
+
+    strong {
+      color: var(--text);
+    }
+
+    code, pre {
+      font-family: 'Fira Code', monospace;
+      background: var(--code-bg);
+      color: #bae6fd;
+    }
+
+    pre {
+      margin: 1.2rem 0;
+      padding: 1rem 1.2rem;
+      border-radius: 14px;
+      overflow-x: auto;
+      border: 1px solid rgba(56, 189, 248, 0.18);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+    }
+
+    pre code {
+      display: block;
+      white-space: pre;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1.2rem;
+      color: var(--text-muted);
+    }
+
+    th,
+    td {
+      padding: 0.75rem 0.9rem;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    th {
+      background: rgba(15, 23, 42, 0.65);
+      color: var(--text);
+      text-align: left;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2.5rem 1rem 3.5rem;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+    }
+
+    a {
+      color: var(--accent);
+    }
+
+    @media (max-width: 720px) {
+      header {
+        padding-top: 3.5rem;
+      }
+    }
+
+    @media (max-width: 640px) {
+      :root {
+        font-size: 14px;
+      }
+
+      header {
+        padding: 3rem 1.75rem 2.5rem;
+      }
+
+      main {
+        width: min(1100px, 96vw);
+        margin: 0 auto 3.5rem;
+        gap: 2.5rem;
+      }
+
+      section {
+        padding: 1.6rem 1.4rem;
+      }
+
+      pre {
+        font-size: 0.92rem;
+        padding: 0.9rem 1rem;
+      }
+
+      pre code {
+        white-space: pre-wrap;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="global-nav" aria-label="グローバル ナビゲーション">
+      <a href="index.html">
+        <span aria-hidden="true">🏠</span>
+        <span>ホーム</span>
+      </a>
+      <a href="index-en.html">
+        <span aria-hidden="true">🌐</span>
+        <span>英語版</span>
+      </a>
+    </nav>
+    <img src="images/JQ_Lite_sm.png" alt="JQ::Lite のロゴ" class="logo">
+    <h1>JQ::Lite — ビジョン</h1>
+    <p class="lead">JQ::Lite は、jq に着想を得た軽量な JSON プロセッサ兼 Perl モジュールです。構造化データをすべての人とマシンに開放するというビジョンのもと、シンプルかつ高速に扱える体験を提供します。</p>
+    <nav class="tab-nav" aria-label="ビジョン セクション">
+      <a href="index.html">🏠 ホーム</a>
+      <a href="#overview">📜 概要</a>
+      <a href="#global-demand">🌍 グローバル需要</a>
+      <a href="#common-language">💾 共通言語</a>
+      <a href="#perl-renaissance">🐪 Perl ルネサンス</a>
+      <a href="#open-data">🌐 オープンデータ</a>
+      <a href="#automation">⚡ 自動化時代</a>
+      <a href="#ecosystem">🚀 エコシステム</a>
+      <a href="#impact">✨ インパクト</a>
+      <a href="#conclusion">📝 結論</a>
+    </nav>
+  </header>
+
+  <main>
+    <section id="overview">
+      <h2>📜 概要</h2>
+      <p><strong>JQ::Lite</strong> は <strong>jq にインスパイアされた軽量な JSON プロセッサ兼 Perl モジュール</strong> です。JSON ハンドリングを簡単かつ高速にするだけでなく、構造化データをだれもが扱えるようにすることを目指しています。</p>
+      <p>プロジェクト全体のゴールは、世界中のあらゆる環境に <strong>軽量でオープン、人にもマシンにも読みやすいデータ処理</strong> を届けることです。</p>
+    </section>
+
+    <section id="global-demand">
+      <h2>🌍 1. 軽量な JSON 処理に対する世界的需要への対応</h2>
+      <p>JSON は API やオブザーバビリティ、構成管理、AI 入力に至るまで、モダン IT の背骨となっています。それにもかかわらず、JSON を扱う多くのツールは重く、言語やランタイムに縛られてしまいます。</p>
+      <p>そこで JQ::Lite は、以下のようなシンプルさを求める環境にフォーカスしています。</p>
+      <ul>
+        <li>サーバー、IoT ノード、エッジデバイス</li>
+        <li>エアギャップ環境のデータセンターや監視エージェント</li>
+        <li>JSON を手軽にパース・フィルタ・変換したい開発者</li>
+      </ul>
+      <p><strong>単一ファイルで依存が最小限な Perl ネイティブの JSON プロセッサ</strong> として設計された JQ::Lite は、jq が動かない場所でも動作します。</p>
+    </section>
+
+    <section id="common-language">
+      <h2>💾 2. 人とマシンの共通言語を築く</h2>
+      <p>現代のデータ世界は JSON を中心に動いています。API も、監視ツールも、AI エージェントも同じ言語を話します。</p>
+      <p>JQ::Lite は次の特徴によって、それを最大限に活かします。</p>
+      <ul>
+        <li><strong>「JSON 入力 / JSON 出力」</strong> がデフォルト</li>
+        <li>UNIX パイプラインとの互換性</li>
+        <li><strong>CLI</strong> と <strong>Perl モジュール</strong> の両方で利用可能</li>
+      </ul>
+      <p>これにより、システムや言語、人間とマシンの間を流れるデータをつなぐ存在になります。シェルスクリプトから ChatGPT を活用する AIOps パイプラインまで、幅広く活躍します。</p>
+    </section>
+
+    <section id="perl-renaissance">
+      <h2>🐪 3. Perl をユニバーサルなデータユーティリティ言語として再興する</h2>
+      <p>Perl はテキスト処理のために生まれました。いま、その対象をテキストから <strong>構造化データ</strong> へと進化させます。</p>
+      <p>JQ::Lite は、次のような <strong>モダン Perl ルネサンス</strong> を象徴しています。</p>
+      <ul>
+        <li>シンプルさと表現力の両立</li>
+        <li>ポータビリティとパワーの融合</li>
+        <li>「どこでも動く」をデザイン哲学に据えること</li>
+      </ul>
+      <p>クラシックな Perl の強みと JSON ネイティブな設計を組み合わせることで、JQ::Lite は <strong>コマンドラインの中心に Perl が存在すること</strong> を再び示します。</p>
+    </section>
+
+    <section id="open-data">
+      <h2>🌐 4. オープンデータ ワークフローを推進する</h2>
+      <p>いまやデータ処理の多くは <strong>プロプライエタリなエコシステムやクラウド特化の API</strong> に依存しています。JQ::Lite はそうした境界を打ち破ります。</p>
+      <ul>
+        <li>100% オープンソースでベンダーロックインなし</li>
+        <li>オフラインや制限されたネットワークでも動作</li>
+        <li>クラウド依存も複雑なインストールも不要</li>
+      </ul>
+      <p>オブザーバビリティデータ、API レスポンス、AI テレメトリなど、どのような用途でも <strong>オープンでポータブル、再現性のあるパイプライン</strong> を構築できます。</p>
+    </section>
+
+    <section id="automation">
+      <h2>⚡ 5. テキスト駆動型オートメーション時代への備え</h2>
+      <p><strong>Infrastructure as Text</strong> と <strong>Telemetry as JSON</strong> の時代に突入し、人間とマシンが構造化データを直接分析するようになっています。</p>
+      <p>JQ::Lite は次のような点で、この新時代に備えた設計です。</p>
+      <ul>
+        <li>Git で追跡できるデータ変換を実現</li>
+        <li>自動化ボットや LLM とスムーズに連携</li>
+        <li>「抽出 → 変換 → 判断」のワークフローをシンプルに</li>
+      </ul>
+      <p>JQ::Lite を使えば、JSON データは <strong>読みやすく、バージョン管理でき、自動化しやすい</strong> 形へと生まれ変わり、AI が支援するオペレーションの基盤となります。</p>
+    </section>
+
+    <section id="ecosystem">
+      <h2>🚀 6. Perl エコシステムとともに進化する</h2>
+      <p>JQ::Lite は単体で存在するわけではありません。広がりつつあるエコシステムの中核です。</p>
+      <p><strong>Sys::Monitor::Lite</strong> などのモジュールと組み合わせることで、次のようなシームレスなフローが生まれます。</p>
+      <pre><code>Sys::Monitor::Lite  →  JSON メトリクス
+      ↓
+jq-lite              →  フィルター / 集約 / 変換
+      ↓
+Bot / Script / CLI   →  通知 / 実行 / 可視化</code></pre>
+      <p>これにより、<strong>監視と自動化のスタック全体</strong> を Perl だけで構成でき、透明性と外部依存ゼロを実現します。</p>
+    </section>
+
+    <section id="impact">
+      <h2>✨ グローバルなインパクトの概要</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>視点</th>
+            <th>インパクト</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>🌍 社会</td>
+            <td>構造化データをどこでも利用可能にする</td>
+          </tr>
+          <tr>
+            <td>💾 技術</td>
+            <td>Perl と最新 JSON エコシステムを橋渡しする</td>
+          </tr>
+          <tr>
+            <td>🐪 Perl</td>
+            <td>Perl をユニバーサルなコマンドラインユーティリティ言語として復権させる</td>
+          </tr>
+          <tr>
+            <td>⚙️ 運用</td>
+            <td>オープンでオフラインでも動作するベンダーフリーなデータ処理を実現</td>
+          </tr>
+          <tr>
+            <td>🤖 未来</td>
+            <td>AI / LLM と連携するテキスト駆動の自動化の基盤を築く</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="conclusion">
+      <h2>📝 結論</h2>
+      <p><strong>JQ::Lite</strong> はコマンドラインの JSON ツールにとどまりません。<strong>オープンでシンプル、かつユニバーサル</strong> な哲学を体現し、データをサイロから解き放ち、人とマシンの双方が活用できる未来への一歩です。</p>
+      <p>このプロジェクトが、世界中で軽量かつオープン、Perl で駆動するデータ文化を育むきっかけになることを願っています。</p>
+    </section>
+  </main>
+
+  <footer>
+    © 2025 Shingo Kawamura
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the English navigation labels and section headings in vision.html with Japanese phrasing to align with the localized content
- update the ecosystem flow diagram terminology to Japanese so the entire page reads consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe0cbb0e5083209fc74c72367d0c81