### PR TITLE
Add English vision page

### DIFF
--- a/vision-en.html
+++ b/vision-en.html
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JQ::Lite — Vision</title>
+  <link rel="icon" href="images/JQ_Lite_sm.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f172a;
+      --bg-alt: #111827;
+      --bg-card: rgba(15, 23, 42, 0.7);
+      --text: #e2e8f0;
+      --text-muted: #94a3b8;
+      --accent: #38bdf8;
+      --accent-strong: #0ea5e9;
+      --code-bg: rgba(15, 23, 42, 0.9);
+      font-size: clamp(15px, 1.2vw, 18px);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.2), transparent 40%),
+                  radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.2), transparent 35%),
+                  var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow-x: hidden;
+    }
+
+    header {
+      padding: clamp(2rem, 5vw, 5rem) clamp(1.5rem, 6vw, 6rem);
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .global-nav {
+      position: absolute;
+      top: clamp(1rem, 3vw, 2rem);
+      right: clamp(1.5rem, 5vw, 4rem);
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+
+    .global-nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.55rem 1.15rem;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.55);
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 600;
+      transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    }
+
+    .global-nav a:hover,
+    .global-nav a:focus-visible {
+      border-color: rgba(56, 189, 248, 0.55);
+      box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+      transform: translateY(-2px);
+      outline: none;
+    }
+
+    header::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, rgba(14, 165, 233, 0.35), rgba(59, 130, 246, 0.25));
+      opacity: 0.65;
+      filter: blur(120px);
+      z-index: -1;
+    }
+
+    .logo {
+      width: clamp(190px, 30vw, 260px);
+      height: auto;
+      display: block;
+      margin: 0 auto clamp(1.5rem, 4vw, 3rem);
+      filter: drop-shadow(0 12px 24px rgba(8, 47, 73, 0.6));
+    }
+
+    h1 {
+      font-size: clamp(2.5rem, 5vw, 3.8rem);
+      margin-bottom: 1rem;
+      letter-spacing: -0.02em;
+      font-weight: 700;
+    }
+
+    p.lead {
+      font-size: clamp(1.1rem, 2.5vw, 1.45rem);
+      color: var(--text-muted);
+      max-width: 820px;
+      margin: 0 auto clamp(2rem, 4vw, 3rem);
+    }
+
+    .tab-nav {
+      display: inline-flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.8rem;
+      margin-bottom: clamp(2rem, 4vw, 3rem);
+    }
+
+    .tab-nav a {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.65rem 1.3rem;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.65);
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 600;
+      transition: border 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .tab-nav a:hover,
+    .tab-nav a:focus-visible {
+      border-color: rgba(56, 189, 248, 0.55);
+      box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+      transform: translateY(-2px);
+      outline: none;
+    }
+
+    @media (max-width: 720px) {
+      .global-nav {
+        position: static;
+        margin-bottom: 1.5rem;
+        gap: 0.6rem;
+      }
+    }
+
+    main {
+      width: min(1100px, 92vw);
+      margin: 0 auto clamp(4rem, 8vw, 6rem);
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: clamp(3rem, 6vw, 4.5rem);
+    }
+
+    section {
+      background: var(--bg-card);
+      border: 1px solid rgba(148, 163, 184, 0.12);
+      border-radius: 22px;
+      padding: clamp(2rem, 4vw, 3rem);
+      box-shadow: 0 24px 42px rgba(15, 23, 42, 0.45);
+      backdrop-filter: blur(12px);
+    }
+
+    section h2 {
+      margin-top: 0;
+      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      margin-bottom: 1.2rem;
+    }
+
+    ul {
+      padding-left: 1.2rem;
+      margin: 1rem 0;
+      color: var(--text-muted);
+    }
+
+    li + li {
+      margin-top: 0.35rem;
+    }
+
+    p {
+      color: var(--text-muted);
+      margin: 0 0 1rem 0;
+    }
+
+    strong {
+      color: var(--text);
+    }
+
+    code, pre {
+      font-family: 'Fira Code', monospace;
+      background: var(--code-bg);
+      color: #bae6fd;
+    }
+
+    pre {
+      margin: 1.2rem 0;
+      padding: 1rem 1.2rem;
+      border-radius: 14px;
+      overflow-x: auto;
+      border: 1px solid rgba(56, 189, 248, 0.18);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+    }
+
+    pre code {
+      display: block;
+      white-space: pre;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1.2rem;
+      color: var(--text-muted);
+    }
+
+    th,
+    td {
+      padding: 0.75rem 0.9rem;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+    }
+
+    th {
+      background: rgba(15, 23, 42, 0.65);
+      color: var(--text);
+      text-align: left;
+    }
+
+    footer {
+      text-align: center;
+      padding: 2.5rem 1rem 3.5rem;
+      color: var(--text-muted);
+      font-size: 0.95rem;
+    }
+
+    a {
+      color: var(--accent);
+    }
+
+    @media (max-width: 720px) {
+      header {
+        padding-top: 3.5rem;
+      }
+    }
+
+    @media (max-width: 640px) {
+      :root {
+        font-size: 14px;
+      }
+
+      header {
+        padding: 3rem 1.75rem 2.5rem;
+      }
+
+      main {
+        width: min(1100px, 96vw);
+        margin: 0 auto 3.5rem;
+        gap: 2.5rem;
+      }
+
+      section {
+        padding: 1.6rem 1.4rem;
+      }
+
+      pre {
+        font-size: 0.92rem;
+        padding: 0.9rem 1rem;
+      }
+
+      pre code {
+        white-space: pre-wrap;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <nav class="global-nav" aria-label="Global navigation">
+      <a href="index-en.html">
+        <span aria-hidden="true">🏠</span>
+        <span>Home</span>
+      </a>
+      <a href="vision.html">
+        <span aria-hidden="true">🇯🇵</span>
+        <span>日本語版</span>
+      </a>
+    </nav>
+    <img src="images/JQ_Lite_sm.png" alt="JQ::Lite logo" class="logo">
+    <h1>JQ::Lite — Vision</h1>
+    <p class="lead">JQ::Lite is a lightweight JSON processor and Perl module inspired by jq. Our vision is to make structured data approachable, fast, and open for everyone and every machine.</p>
+    <nav class="tab-nav" aria-label="Vision sections">
+      <a href="index-en.html">🏠 Home</a>
+      <a href="#overview">📜 Overview</a>
+      <a href="#global-demand">🌍 Global demand</a>
+      <a href="#common-language">💾 Common language</a>
+      <a href="#perl-renaissance">🐪 Perl renaissance</a>
+      <a href="#open-data">🌐 Open data</a>
+      <a href="#automation">⚡ Automation era</a>
+      <a href="#ecosystem">🚀 Ecosystem</a>
+      <a href="#impact">✨ Impact</a>
+      <a href="#conclusion">📝 Conclusion</a>
+    </nav>
+  </header>
+
+  <main>
+    <section id="overview">
+      <h2>📜 Overview</h2>
+      <p><strong>JQ::Lite</strong> is a <strong>jq-inspired JSON processor and Perl module</strong>. It simplifies working with JSON while keeping it fast, portable, and accessible.</p>
+      <p>The overarching goal is to deliver <strong>lightweight, open, human- and machine-readable data tooling</strong> to any environment around the world.</p>
+    </section>
+
+    <section id="global-demand">
+      <h2>🌍 1. Meeting worldwide demand for lightweight JSON tooling</h2>
+      <p>JSON powers modern IT—from APIs and observability pipelines to configuration management and AI inputs. Yet many tools remain heavy, locked to specific languages, or unavailable in constrained environments.</p>
+      <p>JQ::Lite focuses on scenarios that need simplicity:</p>
+      <ul>
+        <li>Servers, IoT nodes, and edge devices</li>
+        <li>Air-gapped data centers and monitoring agents</li>
+        <li>Builders who just want to parse, filter, and transform JSON quickly</li>
+      </ul>
+      <p>Designed as a <strong>single-file, dependency-light, Perl-native JSON processor</strong>, JQ::Lite keeps working even where jq cannot.</p>
+    </section>
+
+    <section id="common-language">
+      <h2>💾 2. Creating a common language between people and machines</h2>
+      <p>The data world runs on JSON. APIs, monitoring platforms, and AI agents all speak the same structure.</p>
+      <p>JQ::Lite amplifies this with:</p>
+      <ul>
+        <li><strong>JSON-in / JSON-out</strong> by default</li>
+        <li>Seamless compatibility with UNIX pipelines</li>
+        <li>Availability as both a <strong>CLI</strong> and a <strong>Perl module</strong></li>
+      </ul>
+      <p>It becomes connective tissue between systems, languages, humans, and automation—from shell scripts to ChatGPT-powered AIOps workflows.</p>
+    </section>
+
+    <section id="perl-renaissance">
+      <h2>🐪 3. Revitalizing Perl as a universal data utility language</h2>
+      <p>Perl was born for text processing. Now it embraces <strong>structured data</strong>.</p>
+      <p>JQ::Lite embodies a <strong>modern Perl renaissance</strong> built on:</p>
+      <ul>
+        <li>Balancing simplicity with expressiveness</li>
+        <li>Fusing portability with power</li>
+        <li>Designing for “runs anywhere” from the start</li>
+      </ul>
+      <p>By combining classic Perl strengths with JSON-native design, JQ::Lite reaffirms <strong>Perl at the heart of the command line</strong>.</p>
+    </section>
+
+    <section id="open-data">
+      <h2>🌐 4. Accelerating open-data workflows</h2>
+      <p>Data processing is increasingly locked into <strong>proprietary ecosystems and cloud-only APIs</strong>. JQ::Lite breaks down those walls.</p>
+      <ul>
+        <li>100% open source with zero vendor lock-in</li>
+        <li>Operational even offline or on restricted networks</li>
+        <li>No cloud dependencies or complex installers required</li>
+      </ul>
+      <p>Whether it is observability data, API responses, or AI telemetry, JQ::Lite enables <strong>open, portable, reproducible pipelines</strong>.</p>
+    </section>
+
+    <section id="automation">
+      <h2>⚡ 5. Preparing for the text-driven automation era</h2>
+      <p>The era of <strong>Infrastructure as Text</strong> and <strong>Telemetry as JSON</strong> is here, with humans and machines analyzing structured data side-by-side.</p>
+      <p>JQ::Lite is ready for it with:</p>
+      <ul>
+        <li>Data transformations that are easy to track in Git</li>
+        <li>Effortless hand-offs to automation bots and LLMs</li>
+        <li>Simplified “extract → transform → decide” workflows</li>
+      </ul>
+      <p>With JQ::Lite, JSON becomes <strong>readable, versionable, and automation-friendly</strong>, forming the backbone of AI-assisted operations.</p>
+    </section>
+
+    <section id="ecosystem">
+      <h2>🚀 6. Growing alongside the Perl ecosystem</h2>
+      <p>JQ::Lite is a core part of a growing ecosystem rather than a standalone tool.</p>
+      <p>In tandem with modules like <strong>Sys::Monitor::Lite</strong>, it enables streamlined flows such as:</p>
+      <pre><code>Sys::Monitor::Lite  →  JSON metrics
+      ↓
+jq-lite              →  filter / aggregate / transform
+      ↓
+Bot / Script / CLI   →  notify / execute / visualize</code></pre>
+      <p>This makes it possible to build an <strong>end-to-end monitoring and automation stack</strong> in Perl—transparent and free of external dependencies.</p>
+    </section>
+
+    <section id="impact">
+      <h2>✨ Snapshot of global impact</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Perspective</th>
+            <th>Impact</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>🌍 Society</td>
+            <td>Make structured data usable everywhere</td>
+          </tr>
+          <tr>
+            <td>💾 Technology</td>
+            <td>Bridge Perl with the modern JSON ecosystem</td>
+          </tr>
+          <tr>
+            <td>🐪 Perl</td>
+            <td>Restore Perl as a universal command-line utility language</td>
+          </tr>
+          <tr>
+            <td>⚙️ Operations</td>
+            <td>Deliver open, offline-capable, vendor-free data processing</td>
+          </tr>
+          <tr>
+            <td>🤖 Future</td>
+            <td>Lay the groundwork for text-driven automation with AI and LLMs</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="conclusion">
+      <h2>📝 Conclusion</h2>
+      <p><strong>JQ::Lite</strong> is more than a command-line JSON tool. It embodies an <strong>open, simple, and universal</strong> philosophy that liberates data from silos and empowers both humans and machines.</p>
+      <p>We hope this project sparks a lightweight, open, Perl-powered data culture around the globe.</p>
+    </section>
+  </main>
+
+  <footer>
+    © 2025 Shingo Kawamura
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an English version of the vision page that mirrors the Japanese layout and styling
- include navigation between the English and Japanese pages for easy access

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68fe0fa3f0a483208846755ce7f733a6