### PR TITLE
Bump distribution version to 1.36

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+1.36  2025-11-02
+    - Release jq-compatible @uri formatter and percent-encoding helper.
+    - Declare Encode dependency and document formatter usage.
+
 1.35  2025-11-01
     - Release base64 formatter support and dependency metadata updates.
 

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -44,7 +44,7 @@ Functions are grouped by purpose for easier lookup.
 | `split(sep)`, `join(sep)`            | Split and join                       |
 | `substr(start, len)`                 | Substring extraction                 |
 | `replace(old, new)`                  | Replace substring (literal)          |
-| `@csv`, `@tsv`, `@base64`            | Format value as CSV/TSV row or Base64 string |
+| `@csv`, `@tsv`, `@base64`, `@uri`    | Format value as CSV/TSV row, Base64 string, or percent-encoded URI |
 | `explode()`, `implode()`             | String ↔ Unicode code points         |
 | `tostring`, `tojson`, `fromjson`     | Serialization utilities              |
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -114,6 +114,7 @@ t/transpose.t
 t/trim.t
 t/trimstr.t
 t/tsv_format.t
+t/uri_format.t
 t/type.t
 t/unique_by.t
 t/values.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -23,6 +23,7 @@ WriteMakefile(
     MIN_PERL_VERSION => '5.014',
     PREREQ_PM        => {
         'JSON::PP'        => 0,
+        'Encode'          => 0,
         'Test::More'      => 0,
         'FindBin'         => 0,
         'Getopt::Long'    => 0,

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.35';
+our $VERSION = '1.36';
 
 sub new {
     my ($class, %opts) = @_;
@@ -57,7 +57,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.35
+Version 1.36
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Filters.pm
+++ b/lib/JQ/Lite/Filters.pm
@@ -1729,6 +1729,13 @@ sub apply {
             return 1;
         }
 
+        # support for @uri (percent-encode value)
+        if ($part eq '@uri' || $part eq '@uri()') {
+            @next_results = map { JQ::Lite::Util::_apply_uri($_) } @results;
+            @$out_ref = @next_results;
+            return 1;
+        }
+
         # support for split("separator")
         if ($part =~ /^split\((.+)\)$/) {
             my $separator = JQ::Lite::Util::_parse_string_argument($1);

--- a/lib/JQ/Lite/Util.pm
+++ b/lib/JQ/Lite/Util.pm
@@ -7,6 +7,7 @@ use JSON::PP ();
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 use MIME::Base64 qw(encode_base64);
+use Encode qw(encode);
 use B ();
 use JQ::Lite::Expression ();
 
@@ -2928,6 +2929,32 @@ sub _apply_base64 {
     }
 
     return encode_base64($text, '');
+}
+
+sub _apply_uri {
+    my ($value) = @_;
+
+    my $text;
+
+    if (!defined $value) {
+        $text = 'null';
+    }
+    elsif (ref($value) eq 'JSON::PP::Boolean') {
+        $text = $value ? 'true' : 'false';
+    }
+    elsif (!ref $value) {
+        $text = "$value";
+    }
+    elsif (ref $value eq 'ARRAY' || ref $value eq 'HASH') {
+        $text = _encode_json($value);
+    }
+    else {
+        $text = "$value";
+    }
+
+    my $encoded = encode('UTF-8', $text);
+    $encoded =~ s/([^A-Za-z0-9\-._~])/sprintf('%%%02X', ord($1))/ge;
+    return $encoded;
 }
 
 sub _format_csv_field {

--- a/t/uri_format.t
+++ b/t/uri_format.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my @space = $jq->run_query('"hello world"', '@uri');
+is_deeply(\@space, ['hello%20world'], '@uri encodes spaces in strings');
+
+my @utf8 = $jq->run_query('"こんにちは"', '@uri');
+is_deeply(\@utf8, ['%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF'], '@uri encodes UTF-8 characters');
+
+my @number = $jq->run_query('42', '@uri');
+is_deeply(\@number, ['42'], '@uri leaves numeric characters as-is');
+
+my @null = $jq->run_query('null', '@uri');
+is_deeply(\@null, ['null'], '@uri renders null as its literal text');
+
+my @object = $jq->run_query('{"foo":"bar"}', '@uri');
+is_deeply(\@object, ['%7B%22foo%22%3A%22bar%22%7D'], '@uri encodes objects via JSON representation');
+
+done_testing();


### PR DESCRIPTION
## Summary
- bump the JQ::Lite distribution version to 1.36
- add release notes covering the new @uri formatter and dependency updates

## Testing
- prove -lv t/uri_format.t

------
https://chatgpt.com/codex/tasks/task_e_6906a28ffa408320b7166a43bfad20cf