### PR TITLE
Fix UTF-8 handling for @uri filter

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -36,6 +36,7 @@ t/contains.t
 t/contains_function.t
 t/count.t
 t/csv_format.t
+t/decode_utf8_input.t
 t/default.t
 t/del.t
 t/delpaths.t

--- a/lib/JQ/Lite/Util.pm
+++ b/lib/JQ/Lite/Util.pm
@@ -7,7 +7,7 @@ use JSON::PP ();
 use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 use MIME::Base64 qw(encode_base64);
-use Encode qw(encode);
+use Encode qw(encode is_utf8);
 use B ();
 use JQ::Lite::Expression ();
 
@@ -22,6 +22,11 @@ sub _encode_json {
 
 sub _decode_json {
     my ($text) = @_;
+
+    if (defined $text && is_utf8($text, 1)) {
+        $text = encode('UTF-8', $text);
+    }
+
     return $JSON_DECODER->decode($text);
 }
 

--- a/t/decode_utf8_input.t
+++ b/t/decode_utf8_input.t
@@ -1,0 +1,17 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Encode qw(decode);
+use JQ::Lite;
+
+my $json = decode('UTF-8', '"こんにちは！"');
+my $jq   = JQ::Lite->new;
+
+my @results = eval { $jq->run_query($json, '@uri') };
+my $error   = $@;
+
+is($error, '', 'running @uri on decoded UTF-8 input does not throw');
+is_deeply(\@results, ['%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%81%AF%EF%BC%81'], 'UTF-8 text is percent-encoded');
+
+done_testing();


### PR DESCRIPTION
## Summary
- ensure `_decode_json` converts Perl UTF-8 character strings back to UTF-8 bytes before decoding JSON
- add a regression test that feeds decoded UTF-8 text into `run_query` and verifies `@uri` percent-encodes it

## Testing
- prove -vl t/decode_utf8_input.t t/uri_format.t

------
https://chatgpt.com/codex/tasks/task_e_6906aa793e2c8320926fab70c6f8b296