### PR TITLE
Restrict YAML CLI test to Perl 5.40+

### DIFF
--- a/t/yaml_cli.t
+++ b/t/yaml_cli.t
@@ -2,9 +2,9 @@ use strict;
 use warnings;
 use Test::More;
 
-# Skip this test on Perl 5.20–5.26 because of known compatibility issues
-if ($] >= 5.020000 && $] < 5.027000) {
-    plan skip_all => "Skipped on Perl 5.20–5.26 due to known incompatibility";
+# YAML support relies on functionality available only in Perl 5.40 and newer
+if ($] < 5.040000) {
+    plan skip_all => "YAML tests require Perl 5.40 or newer";
 }
 
 use IPC::Open3;


### PR DESCRIPTION
## Summary
- require Perl 5.40 or newer before running the YAML CLI test to reflect updated compatibility requirements

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e715d39b88320bc5f126dfa5db33f)