### PR TITLE
Bump distribution version to 1.40

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+1.40  2025-11-10
+    - Release jq-style string interpolation for double-quoted strings,
+      matching jq's serialization of scalars, arrays, and objects.
+
 1.39  2025-11-09
     - Add jq-compatible --arg option to the CLI and wire variables into the engine.
     - Allow passing initial variables when constructing JQ::Lite instances.

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.39';
+our $VERSION = '1.40';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.39
+Version 1.40
 
 =head1 SYNOPSIS
 

--- a/t/string_interpolation.t
+++ b/t/string_interpolation.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new(vars => { a => 'hello', b => 'world' });
+my @results = $jq->run_query('null', '{"msg": "\($a) \($b)"}');
+
+is_deeply(
+    \@results,
+    [ { msg => 'hello world' } ],
+    'string interpolation uses provided variables',
+);
+
+my $data = <<'JSON';
+[
+  {"name": "Alice", "age": 30},
+  {"name": "Bob",   "age": 25}
+]
+JSON
+
+$jq = JQ::Lite->new;
+@results = $jq->run_query($data, '.[] | {"desc": "\(.name) is \(.age)"}');
+
+is_deeply(
+    \@results,
+    [
+        { desc => 'Alice is 30' },
+        { desc => 'Bob is 25' },
+    ],
+    'string interpolation supports expressions using the current context',
+);
+
+$jq = JQ::Lite->new;
+@results = $jq->run_query('[{"items": [1,2]}]', '.[] | {"items": "\(.items)"}');
+
+is_deeply(
+    \@results,
+    [ { items => '[1,2]' } ],
+    'string interpolation stringifies arrays as JSON',
+);
+
+$jq = JQ::Lite->new;
+@results = $jq->run_query('[{"flag": true}]', '.[] | {"flag": "\(.flag)"}');
+
+is_deeply(
+    \@results,
+    [ { flag => 'true' } ],
+    'boolean values are stringified to lowercase words',
+);
+
+done_testing();


### PR DESCRIPTION
## Summary
- bump the JQ::Lite distribution version number to 1.40
- record the 1.40 release with notes about jq-style string interpolation in Changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e7b9c6b508320a9064e3011ed893d)