### PR TITLE
Bump version to 1.43

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+1.43  2025-11-09
+    - Release jq-compatible @base64d formatter with documentation and tests.
+
 1.42  2025-11-09
     - Release jq-compatible ascii_upcase filter along with docs and tests.
 

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -45,7 +45,7 @@ Functions are grouped by purpose for easier lookup.
 | `split(sep)`, `join(sep)`            | Split and join                       |
 | `substr(start, len)`                 | Substring extraction                 |
 | `replace(old, new)`                  | Replace substring (literal)          |
-| `@json`, `@csv`, `@tsv`, `@base64`, `@uri` | Format value as JSON, CSV/TSV row, Base64 string, or percent-encoded URI |
+| `@json`, `@csv`, `@tsv`, `@base64`, `@base64d`, `@uri` | Format value as JSON, CSV/TSV row, Base64 string, decode Base64 text, or percent-encoded URI |
 | `explode()`, `implode()`             | String ↔ Unicode code points         |
 | `tostring`, `tojson`, `fromjson`     | Serialization utilities              |
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -24,6 +24,7 @@ t/arrays.t
 t/assignment.t
 t/avg_by.t
 t/base64_format.t
+t/base64d.t
 t/basic.t
 t/case_transform.t
 t/ceil_floor.t

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.42';
+our $VERSION = '1.43';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.42
+Version 1.43
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Filters.pm
+++ b/lib/JQ/Lite/Filters.pm
@@ -1750,6 +1750,13 @@ sub apply {
             return 1;
         }
 
+        # support for @base64d (decode base64-encoded string)
+        if ($part eq '@base64d' || $part eq '@base64d()') {
+            @next_results = map { JQ::Lite::Util::_apply_base64d($_) } @results;
+            @$out_ref = @next_results;
+            return 1;
+        }
+
         # support for @uri (percent-encode value)
         if ($part eq '@uri' || $part eq '@uri()') {
             @next_results = map { JQ::Lite::Util::_apply_uri($_) } @results;

--- a/t/base64d.t
+++ b/t/base64d.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my @decoded = $jq->run_query('"aGVsbG8h"', '@base64d');
+is_deeply(\@decoded, ['hello!'], '@base64d decodes base64 text');
+
+my @roundtrip = $jq->run_query('{"foo":"bar"}', '@base64 | @base64d');
+is_deeply(\@roundtrip, ['{"foo":"bar"}'], '@base64d reverses @base64 output');
+
+my $ok = eval { $jq->run_query('"not-base64"', '@base64d'); 1 };
+my $error = $@;
+
+ok(!$ok, '@base64d throws on invalid input');
+like($error, qr/\@base64d\(\): input must be base64 text/, 'invalid base64 input reports descriptive error');
+
+done_testing();


### PR DESCRIPTION
## Summary
- update the distribution version metadata and documentation to 1.43
- record the new release entry for the @base64d formatter in the change log

## Testing
- prove -l t/base64d.t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691017241bb483208211778c5c8809a9)