### PR TITLE
Add Alpine Linux official package installation notes to site

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -510,6 +510,11 @@
           <p>Install from CPAN to get started fast. All dependencies are resolved for you.</p>
         </div>
         <div class="card">
+          <h3>Alpine Linux (official package)</h3>
+          <pre><code>apk add perl-jq-lite</code></pre>
+          <p>Available as an official module in Alpine Linux. Install directly from the community repository.</p>
+        </div>
+        <div class="card">
           <h3>Homebrew (macOS)</h3>
           <pre><code>brew tap kawamurashingo/jq-lite
 brew install --HEAD jq-lite</code></pre>

--- a/index.html
+++ b/index.html
@@ -510,6 +510,11 @@
           <p>最速で試すなら CPAN が便利。依存モジュールもまとめて解決します。</p>
         </div>
         <div class="card">
+          <h3>Alpine Linux (公式パッケージ)</h3>
+          <pre><code>apk add perl-jq-lite</code></pre>
+          <p>Alpine Linux の公式モジュールとして提供されています。コミュニティリポジトリからそのまま導入できます。</p>
+        </div>
+        <div class="card">
           <h3>Homebrew (macOS)</h3>
           <pre><code>brew tap kawamurashingo/jq-lite
 brew install --HEAD jq-lite</code></pre>


### PR DESCRIPTION
## Summary
- add an installation card noting the official Alpine Linux package on the Japanese landing page
- add matching Alpine Linux installation details to the English page

## Testing
- not run (static content change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e14d2059c83209d9922a50987ba5c)