### PR TITLE
Prepare 1.47 release

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+1.47  2025-12-15
+    - Promote release to version 1.47 adding jq-compatible --raw-input/-R
+      plain-text processing with optional slurping and CLI regression tests.
+
 1.46  2025-12-14
     - Promote release to version 1.46 with jq-compatible try/catch filter
       support, documentation, and regression tests.

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -15,6 +15,7 @@ my $decoder;
 my $decoder_module;
 my $decoder_debug   = 0;
 my $decoder_choice;
+my $raw_input       = 0;
 my $raw_output      = 0;
 my $compact_output  = 0;
 my $color_output    = 0;
@@ -35,6 +36,7 @@ Usage:
   jq-lite [options] -f query.jq [file.json]
 
 Options:
+  -R, --raw-input     Read input as raw text instead of JSON (one filter run per line)
   -r, --raw-output     Print raw strings instead of JSON-encoded values
   -c, --compact-output Print JSON results on a single line (no pretty-printing)
   --color              Colorize JSON output (keys, strings, numbers, booleans)
@@ -66,6 +68,7 @@ USAGE
 my ($want_help, $want_version, $help_functions) = (0, 0, 0);
 
 GetOptions(
+    'raw-input|R'    => \$raw_input,
     'raw-output|r'    => \$raw_output,
     'compact-output|c'=> \$compact_output,
     'color'           => \$color_output,
@@ -278,6 +281,7 @@ else {
     $json_text = <STDIN>;
 }
 
+$use_yaml = 0 if $raw_input;
 $use_yaml = 1 if $force_yaml && !$null_input;
 
 if ($use_yaml) {
@@ -285,7 +289,28 @@ if ($use_yaml) {
     warn "[DEBUG] Parsing YAML with $yaml_module\n" if $decoder_debug && $yaml_module;
 }
 
-if ($slurp_input && !$null_input) {
+# ---------- JQ::Lite core ----------
+my $jq = JQ::Lite->new(raw => $raw_output, vars => \%arg_vars);
+
+if ($raw_input) {
+    $use_yaml = 0;    # Raw input is plain text; ignore YAML handling
+}
+
+my @raw_lines;
+if ($raw_input) {
+    my $text = $json_text // '';
+    if ($slurp_input) {
+        $json_text = JSON::PP->new->allow_nonref->encode($text);
+    }
+    else {
+        @raw_lines = split /\r?\n/, $text, -1;
+        if (@raw_lines && $raw_lines[-1] eq '' && $text =~ /\r?\n\z/) {
+            pop @raw_lines;
+        }
+    }
+}
+
+if (!$raw_input && $slurp_input && !$null_input) {
     my $text   = $json_text // '';
     my $length = length $text;
     my $offset = 0;
@@ -310,9 +335,6 @@ if ($slurp_input && !$null_input) {
 
     $json_text = JSON::PP->new->encode(\@values);
 }
-
-# ---------- JQ::Lite core ----------
-my $jq = JQ::Lite->new(raw => $raw_output, vars => \%arg_vars);
 
 sub convert_yaml_to_json {
     my ($text) = @_;
@@ -406,6 +428,10 @@ sub print_results {
 }
 
 # ---------- Interactive mode ----------
+if ($raw_input && !$slurp_input && !defined $query) {
+    die "[ERROR] --raw-input requires a query when not using --slurp.\n";
+}
+
 if (!defined $query) {
     system("stty -icanon -echo");
 
@@ -491,9 +517,24 @@ if (!defined $query) {
 }
 
 # ---------- One-shot mode ----------
-my @results = eval { $jq->run_query($json_text, $query) };
-if ($@) {
-    die "[ERROR] Invalid query: $@\n";
+my @results;
+
+if ($raw_input && !$slurp_input) {
+    my $encoder = JSON::PP->new->allow_nonref;
+    for my $line (@raw_lines) {
+        my $encoded_line = $encoder->encode($line);
+        my @line_results = eval { $jq->run_query($encoded_line, $query) };
+        if ($@) {
+            die "[ERROR] Invalid query: $@\n";
+        }
+        push @results, @line_results;
+    }
+}
+else {
+    @results = eval { $jq->run_query($json_text, $query) };
+    if ($@) {
+        die "[ERROR] Invalid query: $@\n";
+    }
 }
 
 if (!@results) {

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.46';
+our $VERSION = '1.47';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.46
+Version 1.47
 
 =head1 SYNOPSIS
 

--- a/t/raw_input_cli.t
+++ b/t/raw_input_cli.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+use Test::More;
+use IPC::Open3;
+use Symbol qw(gensym);
+
+sub run_cli {
+    my (%opts) = @_;
+    my @cmd = ($^X, 'bin/jq-lite', @{ $opts{args} // [] });
+
+    my $err = gensym;
+    my $pid = open3(my $in, my $out, $err, @cmd);
+
+    if (defined $opts{stdin}) {
+        print {$in} $opts{stdin};
+    }
+    close $in;
+
+    my $stdout = do { local $/; <$out> } // '';
+    my $stderr = do { local $/; <$err> } // '';
+
+    waitpid($pid, 0);
+    my $exit_code = $? >> 8;
+
+    return ($stdout, $stderr, $exit_code);
+}
+
+my ($stdout, $stderr, $exit) = run_cli(
+    args  => [ '-R', '-c', '.' ],
+    stdin => "foo\nbar\n",
+);
+
+is($stdout, "\"foo\"\n\"bar\"\n", '--raw-input processes each line as a separate string');
+like($stderr, qr/^\s*\z/, 'no warnings emitted when reading raw lines');
+is($exit, 0, 'process exits successfully for raw line input');
+
+($stdout, $stderr, $exit) = run_cli(
+    args  => [ '-R', '-s', '-c', '.' ],
+    stdin => "alpha\nbeta\n",
+);
+
+is($stdout, "\"alpha\\nbeta\\n\"\n", '--raw-input with --slurp combines input into a single string');
+like($stderr, qr/^\s*\z/, 'no warnings emitted when slurping raw text');
+is($exit, 0, 'process exits successfully for slurped raw text');
+
+($stdout, $stderr, $exit) = run_cli(
+    args  => [ '-R', '-c', '.', 'nonexistent.json' ],
+);
+
+like($stderr, qr/No such file or directory|Cannot open file/, 'error surfaced when file is missing under --raw-input');
+ok($exit != 0, 'nonexistent file under raw input causes non-zero exit');
+
+done_testing;


### PR DESCRIPTION
## Summary
- bump module version string and documentation to 1.47
- add 1.47 release notes describing new raw-input CLI support

## Testing
- prove -l t/raw_input_cli.t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f2b58d7308320961468201c543728)