### PR TITLE
Release version 1.50

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+1.50  2025-12-18
+    - Promote release to version 1.50.
+    - Allow CLI JSON encoding to accept scalar values when processing
+      --argjson and raw input modes, eliminating warnings and exit failures.
+    - Consolidate raw-input handling under a shared UTF-8 encoder to keep
+      per-line and slurped text output consistent.
+
 1.49  2025-12-17
     - Allow t/path.t to skip cleanly on Perl 5.28 and earlier by removing
       the hard 5.029 requirement.

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -301,9 +301,11 @@ if ($raw_input) {
 
 my @raw_lines;
 if ($raw_input) {
-    my $text = $json_text // '';
+    my $text    = $json_text // '';
+    my $encoder = JSON::PP->new->utf8->allow_nonref;
+
     if ($slurp_input) {
-        $json_text = JSON::PP->new->allow_nonref->encode($text);
+        $json_text = $encoder->encode($text);
     }
     else {
         @raw_lines = split /\r?\n/, $text, -1;
@@ -411,7 +413,7 @@ sub colorize_json {
 # ---------- Output ----------
 sub print_results {
     my @results = @_;
-    my $pp = JSON::PP->new->utf8->canonical;
+    my $pp = JSON::PP->new->utf8->allow_nonref->canonical;
     $pp->pretty unless $compact_output;
     $pp->ascii($ascii_output);
 
@@ -524,7 +526,7 @@ if (!defined $query) {
 my @results;
 
 if ($raw_input && !$slurp_input) {
-    my $encoder = JSON::PP->new->allow_nonref;
+    my $encoder = JSON::PP->new->utf8->allow_nonref;
     for my $line (@raw_lines) {
         my $encoded_line = $encoder->encode($line);
         my @line_results = eval { $jq->run_query($encoded_line, $query) };

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.49';
+our $VERSION = '1.50';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.49
+Version 1.50
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
## Summary
- bump JQ::Lite version to 1.50
- document the release with notes about scalar-safe --argjson handling and raw input UTF-8 encoding consistency

## Testing
- prove -v t/argjson_cli.t t/raw_input_cli.t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943d34be16083209aaf2b31b88594c9)