### PR TITLE
Add jq-style --rawfile CLI support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.52  2025-12-21
+    - Add jq-compatible --rawfile CLI option that loads file contents into
+      variables for downstream filters, along with regression tests and
+      documentation updates.
+
 1.51  2025-12-20
     - Ignore SIGPIPE in the from_file_stdin test helper so closed pipes
       from the CLI under test do not terminate the harness.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ where **simplicity, readability, and low dependency footprint** matter.
 * 🔧 **CLI tool**: `jq-lite`
 
   * `--null-input`, `--slurp`, `--from-file`
-  * `--yaml`, `--arg`, `--argjson`, `--ascii-output`
+  * `--yaml`, `--arg`, `--rawfile`, `--argjson`, `--ascii-output`
 * 📊 **100+ built-in jq functions**
   → see [`FUNCTIONS.md`](FUNCTIONS.md)
 * 💻 **Interactive mode** for exploring JSON

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -45,6 +45,7 @@ Options:
   --use <Module>       Force JSON decoder module (e.g. JSON::PP, JSON::XS, Cpanel::JSON::XS)
   --debug              Show which JSON module is being used
   --arg NAME VALUE     Set jq-style variable $NAME to the string VALUE
+  --rawfile NAME FILE  Set jq-style variable $NAME to the raw contents of FILE
   --argjson NAME JSON  Set jq-style variable $NAME to a JSON-decoded value
   -f, --from-file FILE Read jq filter from FILE instead of the command line
                           (use '-' to read the filter from STDIN)
@@ -113,6 +114,33 @@ GetOptions(
         }
 
         $arg_vars{$var_name} = $decoded;
+    },
+    'rawfile=s'        => sub {
+        my ($opt_name, $var_name) = @_;
+        die "[ERROR] --rawfile requires a variable name\n" if !defined $var_name || $var_name eq '';
+        if ($var_name !~ /^[A-Za-z_]\w*$/) {
+            die "[ERROR] Invalid variable name '$var_name' for --rawfile\n";
+        }
+        die "[ERROR] --rawfile requires a file path\n" if !@ARGV;
+        my $file_path = shift @ARGV;
+        $file_path = '' unless defined $file_path;
+
+        if (!-f $file_path) {
+            warn "[ERROR] Cannot open file '$file_path' for --rawfile $var_name: $!\n";
+            exit 2;
+        }
+
+        open my $fh, '<', $file_path
+          or do {
+            warn "[ERROR] Cannot open file '$file_path' for --rawfile $var_name: $!\n";
+            exit 2;
+          };
+        local $/;
+        my $content = <$fh>;
+        close $fh;
+        $content = '' unless defined $content;
+
+        $arg_vars{$var_name} = $content;
     },
 ) or die "[ERROR] Unknown option(s)\n";
 

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.51';
+our $VERSION = '1.52';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.51
+Version 1.52
 
 =head1 SYNOPSIS
 

--- a/t/rawfile_cli.t
+++ b/t/rawfile_cli.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+
+use IPC::Open3;
+use Symbol qw(gensym);
+use File::Temp qw(tempfile);
+use Test::More;
+
+my ($fh, $filename) = tempfile();
+print {$fh} "alpha\nbeta\n";
+close $fh;
+
+my $err = gensym;
+my $pid = open3(my $in, my $out, $err, $^X, 'bin/jq-lite', '--rawfile', 'doc', $filename, '-n', '$doc | split("\\n") | length');
+close $in;
+
+my $stdout = do { local $/; <$out> } // '';
+my $stderr = do { local $/; <$err> } // '';
+waitpid($pid, 0);
+my $exit_code = $? >> 8;
+
+is($exit_code, 0, '--rawfile accepts an existing file');
+is($stdout, "3\n", 'rawfile contents are exposed as a single string variable');
+like($stderr, qr/^\s*\z/, 'no warnings emitted for valid --rawfile usage');
+
+my $missing_err = gensym;
+my $missing_pid = open3(my $missing_in, my $missing_out, $missing_err, $^X, 'bin/jq-lite', '--rawfile', 'doc', 'nonexistent.raw', '-n', '$doc');
+close $missing_in;
+
+my $missing_stdout = do { local $/; <$missing_out> } // '';
+my $missing_stderr = do { local $/; <$missing_err> } // '';
+waitpid($missing_pid, 0);
+my $missing_exit = $? >> 8;
+
+isnt($missing_exit, 0, '--rawfile exits non-zero when the file cannot be opened');
+like($missing_stderr, qr/Cannot open file 'nonexistent\.raw'/i, 'error message includes the missing filename');
+is($missing_stdout, '', 'no output is produced when --rawfile fails');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a --rawfile CLI option that loads file contents into jq-style variables
- document the new flag alongside other jq-lite options
- add CLI regression coverage for successful and failing --rawfile usage
- bump version to 1.52 for the new release

## Testing
- prove -l t/rawfile_cli.t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945e8fb00b48320b7a4ab48c2b8be7b)