### PR TITLE
Add contains_subset helper with jq-style array semantics

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,13 @@
+1.57  2025-12-24
+
+    - Add opt-in contains_subset() providing jq-style array subset
+      containment (order-insensitive with multiset matching) while
+      preserving legacy contains() semantics for arrays.
+    - Document the new array subset helper and clarify default array
+      behavior for contains().
+    - Cover subset array matching and nested array/object combinations
+      with regression tests.
+
 1.56  2025-12-24
 
     - Parse contains/inside arguments as literal JSON values so null

--- a/FUNCTIONS.md
+++ b/FUNCTIONS.md
@@ -42,7 +42,8 @@ Functions are grouped by purpose for easier lookup.
 | `ascii_upcase()`, `ascii_downcase()` | ASCII-only case conversion           |
 | `trim()`, `ltrimstr()`, `rtrimstr()` | Trim whitespace or prefixes/suffixes |
 | `startswith()`, `endswith()`         | Prefix/suffix test                   |
-| `contains(value)`                    | Substring or array inclusion         |
+| `contains(value)`                    | Substring or array inclusion (legacy array semantics) |
+| `contains_subset(value)`             | jq-style subset inclusion for arrays |
 | `inside(container)`                  | Whether input is inside container    |
 | `split(sep)`, `join(sep)`            | Split and join                       |
 | `substr(start, len)`                 | Substring extraction                 |
@@ -50,6 +51,17 @@ Functions are grouped by purpose for easier lookup.
 | `@json`, `@csv`, `@tsv`, `@base64`, `@base64d`, `@uri` | Format value as JSON, CSV/TSV row, Base64 string, decode Base64 text, or percent-encoded URI |
 | `explode()`, `implode()`             | String ↔ Unicode code points         |
 | `tostring`, `tojson`, `fromjson`     | Serialization utilities              |
+
+**Array containment semantics**
+
+- `contains(value)`: keeps the legacy behavior for arrays—it searches for an
+  element equal to the provided value. Nested arrays must match exactly (order
+  and length) to satisfy equality. Objects still use subset semantics and
+  strings still use substring matching.
+- `contains_subset(value)`: opt-in jq-style subset matching for arrays. The
+  right-hand array is satisfied when every element can be matched anywhere in
+  the left-hand array (order-insensitive) with multiset counting. Nested arrays
+  and objects are compared recursively using the same subset rules.
 
 ---
 

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.56';
+our $VERSION = '1.57';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.56
+Version 1.57
 
 =head1 SYNOPSIS
 
@@ -508,6 +508,20 @@ Example:
   .title | contains("perl")     # => true
   .tags  | contains("json")     # => true
   .meta  | contains("lang")     # => true
+
+=item * contains_subset(value)
+
+Opt-in jq-style subset containment. Behaves like C<contains/1>, but when
+arrays are involved the right-hand array must be a multiset subset of the
+left-hand one. Order does not matter and duplicate elements are honoured.
+Nested arrays inside hashes are evaluated with the same subset rules.
+
+Examples:
+
+  [1,2,3] | contains_subset([2,3])            # => true
+  [1,2,3] | contains_subset([3,2])            # => true
+  [1,2,3] | contains_subset([4])              # => false
+  {"b":{"y":[1,2,3]}} | contains_subset({"b":{"y":[2]}})  # => true
 
 =item * test(pattern[, flags])
 

--- a/lib/JQ/Lite/Filters.pm
+++ b/lib/JQ/Lite/Filters.pm
@@ -1765,6 +1765,14 @@ sub apply {
             return 1;
         }
 
+        # support for contains_subset(value)
+        if ($part =~ /^contains_subset\((.+)\)$/) {
+            my $needle = JQ::Lite::Util::_parse_literal_argument($1);
+            @next_results = map { JQ::Lite::Util::_apply_contains_subset($_, $needle) } @results;
+            @$out_ref = @next_results;
+            return 1;
+        }
+
         # support for inside(container)
         if ($part =~ /^inside\((.+)\)$/) {
             my $container = JQ::Lite::Util::_parse_literal_argument($1);

--- a/t/contains_subset_function.t
+++ b/t/contains_subset_function.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $json = q({
+  "array": [1, 2, 3],
+  "nested": {"x": 10, "y": [1, 2, 3]},
+  "dupes": [1, 2, 2, 3]
+});
+
+my $jq = JQ::Lite->new;
+
+my @subset_in_order      = $jq->run_query($json, '.array | contains_subset([2,3])');
+my @subset_out_of_order  = $jq->run_query($json, '.array | contains_subset([3,2])');
+my @subset_missing       = $jq->run_query($json, '.array | contains_subset([4])');
+my @nested_subset        = $jq->run_query($json, '.nested | contains_subset({"y": [2]})');
+my @dupe_true            = $jq->run_query($json, '.dupes | contains_subset([2,2])');
+my @dupe_false           = $jq->run_query($json, '.array | contains_subset([2,2])');
+
+ok($subset_in_order[0], 'array subset in order is true');
+ok($subset_out_of_order[0], 'array subset out of order is true');
+ok(!$subset_missing[0], 'array subset missing element is false');
+ok($nested_subset[0], 'nested array subset is true');
+ok($dupe_true[0], 'duplicate elements are counted');
+ok(!$dupe_false[0], 'insufficient duplicates returns false');
+
+done_testing;


### PR DESCRIPTION
## Summary
- add a deep containment helper that supports opt-in jq-style array subset matching
- introduce a contains_subset filter to enable jq-compatible array containment without altering legacy contains
- document the new behavior, clarify default array semantics, and bump the release to version 1.57

## Testing
- prove -lr t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bc3fa83448320a3fc11713136f50e)