### PR TITLE
Release version 1.65

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.65  2025-12-27
+
+    - Align `keys` with jq by returning array indices and raising runtime
+      errors on non-array/non-object inputs.
+
 1.64  2025-12-27
 
     - Add jq-compatible --argfile CLI support, decoding JSON files into

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -814,7 +814,7 @@ sub print_supported_functions {
 
 Supported Functions:
   length           - Count array elements, hash keys, or characters in scalars
-  keys             - Extract sorted keys from a hash
+  keys             - Extract sorted keys from a hash or indexes from an array
   keys_unsorted    - Extract object keys without sorting (jq-compatible)
   values           - Extract values from a hash (v0.34)
   sort             - Sort array items

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.64';
+our $VERSION = '1.65';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.64
+Version 1.65
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Filters.pm
+++ b/lib/JQ/Lite/Filters.pm
@@ -527,7 +527,15 @@ sub apply {
         # support for keys
         if ($part eq 'keys') {
             @next_results = map {
-                ref $_ eq 'HASH' ? [ sort keys %$_ ] : undef
+                if (ref $_ eq 'HASH') {
+                    [ sort keys %$_ ];
+                }
+                elsif (ref $_ eq 'ARRAY') {
+                    [ 0 .. $#{$_} ];
+                }
+                else {
+                    die 'keys(): argument must be an object or array';
+                }
             } @results;
             @$out_ref = @next_results;
             return 1;

--- a/t/cli_contract.t
+++ b/t/cli_contract.t
@@ -104,6 +104,20 @@ sub assert_err_contract {
     );
 }
 
+# Runtime error: keys on scalar
+{
+    my $res = run_cmd(
+        cmd   => [$BIN, 'keys'],
+        stdin => qq|null\n|,
+    );
+    assert_err_contract(
+        res    => $res,
+        rc     => 3,
+        prefix => '[RUNTIME]',
+        name   => 'runtime error: keys on scalar',
+    );
+}
+
 # Input error
 {
     my $res = run_cmd(

--- a/t/keys.t
+++ b/t/keys.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use Test::More;
+use JQ::Lite;
+
+my $jq = JQ::Lite->new;
+
+my @array = $jq->run_query("[1,2]\n", 'keys');
+is_deeply($array[0], [0, 1], 'keys returns array indexes');
+
+my $ok = eval {
+    $jq->run_query("null\n", 'keys');
+    1;
+};
+my $err = $@;
+ok(!$ok, 'keys on non-object/non-array throws runtime error');
+like($err, qr/^keys\(\): argument must be an object or array/, 'runtime error message mentions keys');
+
+done_testing();


### PR DESCRIPTION
## Summary
- bump JQ::Lite version to 1.65
- add change log entry describing the jq-compatible `keys` behavior update

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f9fcdaea88320878a0e0ceb32e69b)