### PR TITLE
Bump version to 1.66

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.66  2025-12-27
+
+    - Enforce jq-style runtime errors when getpath is called with a
+      non-array path argument.
+
 1.65  2025-12-27
 
     - Align `keys` with jq by returning array indices and raising runtime

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.65';
+our $VERSION = '1.66';
 
 sub new {
     my ($class, %opts) = @_;

--- a/lib/JQ/Lite/Util/Paths.pm
+++ b/lib/JQ/Lite/Util/Paths.pm
@@ -473,6 +473,14 @@ sub _apply_leaf_paths {
     return \@paths;
 }
 
+sub _validate_path_array {
+    my ($path) = @_;
+
+    die 'getpath(): path must be an array' if ref($path) ne 'ARRAY';
+
+    return [ @$path ];
+}
+
 sub _apply_getpath {
     my ($self, $value, $expr) = @_;
 
@@ -488,14 +496,16 @@ sub _apply_getpath {
     if (!$@ && defined $decoded) {
         if (ref $decoded eq 'ARRAY') {
             if (@$decoded && ref $decoded->[0] eq 'ARRAY') {
-                push @paths, map { [ @$_ ] } @$decoded;
+                for my $path (@$decoded) {
+                    push @paths, _validate_path_array($path);
+                }
             }
             else {
-                push @paths, [ @$decoded ];
+                push @paths, _validate_path_array($decoded);
             }
         }
         else {
-            push @paths, [ $decoded ];
+            die 'getpath(): path must be an array';
         }
     }
 
@@ -506,14 +516,16 @@ sub _apply_getpath {
 
             if (ref $output eq 'ARRAY') {
                 if (@$output && ref $output->[0] eq 'ARRAY') {
-                    push @paths, grep { ref $_ eq 'ARRAY' } @$output;
+                    for my $path (@$output) {
+                        push @paths, _validate_path_array($path);
+                    }
                 }
-                elsif (!@$output || !ref $output->[0]) {
-                    push @paths, [ @$output ];
+                else {
+                    push @paths, _validate_path_array($output);
                 }
             }
-            elsif (!ref $output || ref($output) eq 'JSON::PP::Boolean') {
-                push @paths, [ $output ];
+            else {
+                die 'getpath(): path must be an array';
             }
         }
     }

--- a/t/getpath.t
+++ b/t/getpath.t
@@ -58,4 +58,8 @@ ok(!defined $non_array[0], 'getpath returns undef when traversing non-container 
 my @multi_literal = $jq->run_query($json, '.profile | getpath([["name"], ["age"]])');
 is_deeply($multi_literal[0], ['Alice', 30], 'getpath returns arrayref when multiple literal paths supplied');
 
+my $error = eval { $jq->run_query($json, '.profile | getpath("name")'); 1 };
+ok(!$error, 'getpath throws on non-array path argument');
+like($@, qr/^getpath\(\): path must be an array/, 'error message indicates array requirement');
+
 done_testing;


### PR DESCRIPTION
## Summary
- bump package version to 1.66 in the main module
- document the getpath argument validation release in the changelog

## Testing
- prove -l t/getpath.t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa4b82df883209ad7aecf30aacb35)