### PR TITLE
Handle missing values in from_entries as runtime errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.67  2025-12-27
+
+    - Raise runtime errors from `from_entries` when entries omit values,
+      matching jq behaviour in hash and array entry forms.
+
 1.66  2025-12-27
 
     - Enforce jq-style runtime errors when getpath is called with a

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.66';
+our $VERSION = '1.67';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.65
+Version 1.67
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Util/Transform.pm
+++ b/lib/JQ/Lite/Util/Transform.pm
@@ -472,11 +472,12 @@ sub _normalize_entry {
 
     if (ref $entry eq 'HASH') {
         return unless exists $entry->{key};
+        die 'from_entries(): entry missing value' unless exists $entry->{value};
         return { key => $entry->{key}, value => $entry->{value} };
     }
 
     if (ref $entry eq 'ARRAY') {
-        return unless @$entry >= 2;
+        die 'from_entries(): entry missing value' if @$entry < 2;
         return { key => $entry->[0], value => $entry->[1] };
     }
 

--- a/t/cli_contract.t
+++ b/t/cli_contract.t
@@ -118,6 +118,20 @@ sub assert_err_contract {
     );
 }
 
+# Runtime error: from_entries missing value
+{
+    my $res = run_cmd(
+        cmd   => [$BIN, 'from_entries'],
+        stdin => qq|[{"key":"a"}]\n|,
+    );
+    assert_err_contract(
+        res    => $res,
+        rc     => 3,
+        prefix => '[RUNTIME]',
+        name   => 'runtime error: from_entries missing value',
+    );
+}
+
 # Input error
 {
     my $res = run_cmd(

--- a/t/entries.t
+++ b/t/entries.t
@@ -62,4 +62,13 @@ is_deeply(
     'with_entries filters entries before reconstruction'
 );
 
+my $missing_value = q([{"key": "a"}]);
+my $error;
+eval { $jq->run_query($missing_value, 'from_entries'); 1 } or $error = $@;
+like(
+    $error,
+    qr/^from_entries\(\): entry missing value/,
+    'from_entries throws when an entry is missing its value'
+);
+
 done_testing;


### PR DESCRIPTION
## Summary
- raise a runtime error when from_entries entries omit a value
- expand entries and CLI contract tests to cover missing-value failures
- bump the distribution version to 1.67 and record the release in Changes

## Testing
- prove -lv t/entries.t t/cli_contract.t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa8e2997c8320bc08631d43b59747)