### PR TITLE
Bump version to 1.73

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.73  2026-01-03
+
+    - Guard the CLI broken pipe contract test against SIGPIPE so runs on
+      Perl 5.16 no longer abort with missing TAP output.
+
 1.72  2026-01-03
 
     - Suppress EINVAL warnings when flushing STDOUT on broken pipes in

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.72';
+our $VERSION = '1.73';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - A lightweight jq-like JSON query engine in Perl
 
 =head1 VERSION
 
-Version 1.72
+Version 1.73
 
 =head1 SYNOPSIS
 

--- a/t/cli_contract.t
+++ b/t/cli_contract.t
@@ -275,6 +275,7 @@ sub assert_err_contract {
     my $err = gensym;
     my $pid = open3(my $in, my $out, $err, $BIN, '-R', '.');
 
+    local $SIG{PIPE} = 'IGNORE';
     print {$in} "hello\n" for 1 .. 5000;
     close $in;
 


### PR DESCRIPTION
## Summary
- bump distribution metadata to version 1.73 and document the SIGPIPE guard for the CLI broken pipe test

## Testing
- prove -v t/cli_contract.t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958dadb16c8832096cb2df4d754048d)