### PR TITLE
Bump version to 1.77

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.77  2026-01-05
+
+    - Promote release to version 1.77 aligning with the expanded
+      percentile test coverage.
+
 1.76  2026-01-04
 
     - Promote release to version 1.76 reflecting the updated version

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.76';
+our $VERSION = '1.77';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
-Version 1.76
+ Version 1.77
 
 =head1 SYNOPSIS
 

--- a/t/percentile.t
+++ b/t/percentile.t
@@ -36,4 +36,18 @@ ok(!defined $p_invalid_arg, 'percentile returns undef when the argument is not n
 my ($p_no_numeric) = $jq->run_query($json_invalid, 'percentile(10)');
 ok(!defined $p_no_numeric, 'percentile returns undef when no numeric values are present');
 
+my $json_unsorted = q([40, 10, 50, 20, 30]);
+my ($p_unsorted) = $jq->run_query($json_unsorted, 'percentile(60)');
+is($p_unsorted, 34, 'percentile sorts the array before computing the percentile');
+
+my ($p_underflow) = $jq->run_query($json_ordered, 'percentile(-25)');
+is($p_underflow, 1, 'percentile clamps percentiles below 0 to the minimum value');
+
+my ($p_overflow) = $jq->run_query($json_ordered, 'percentile(175)');
+is($p_overflow, 5, 'percentile clamps percentiles above 100 to the maximum value');
+
+my $json_single = q([99]);
+my ($p_single) = $jq->run_query($json_single, 'percentile(25)');
+is($p_single, 99, 'percentile returns the only element when the array has one value');
+
 done_testing;


### PR DESCRIPTION
## Summary
- bump the module version constant and POD reference to 1.77
- add a 1.77 changelog entry reflecting the expanded percentile coverage

## Testing
- prove -l t/percentile.t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695998dbe4c88320a64c7a4b32fda570)