### PR TITLE
Bump version to 1.78

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.78  2026-01-04
+
+    - Promote release to version 1.78 after tightening percentile
+      validation and extending test coverage.
+
 1.77  2026-01-04
 
     - Promote release to version 1.77 aligning with the expanded

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.77';
+our $VERSION = '1.78';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
- Version 1.77
+ Version 1.78
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Util/Transform.pm
+++ b/lib/JQ/Lite/Util/Transform.pm
@@ -152,6 +152,9 @@ sub _normalize_percentile {
 
     my $fraction = 0 + $value;
 
+    return undef if $fraction != $fraction;             # NaN
+    return undef if ($fraction * 0) != ($fraction * 0); # infinity
+
     if ($fraction > 1) {
         $fraction /= 100 if $fraction <= 100;
     }

--- a/t/percentile.t
+++ b/t/percentile.t
@@ -33,6 +33,15 @@ my ($p_invalid_arg) = $jq->run_query($json_invalid, 'percentile("oops")');
 
 ok(!defined $p_invalid_arg, 'percentile returns undef when the argument is not numeric');
 
+my ($p_nan_arg) = $jq->run_query($json_ordered, 'percentile("NaN")');
+ok(!defined $p_nan_arg, 'percentile returns undef when the argument is NaN');
+
+my ($p_inf_arg) = $jq->run_query($json_ordered, 'percentile("Infinity")');
+ok(!defined $p_inf_arg, 'percentile returns undef when the argument is infinite');
+
+my ($p_inf_negative) = $jq->run_query($json_ordered, 'percentile("-Infinity")');
+ok(!defined $p_inf_negative, 'percentile returns undef when the argument is negative infinity');
+
 my ($p_no_numeric) = $jq->run_query($json_invalid, 'percentile(10)');
 ok(!defined $p_no_numeric, 'percentile returns undef when no numeric values are present');
 


### PR DESCRIPTION
## Summary
- promote release metadata to version 1.78
- document the percentile validation and test updates in the changelog

## Testing
- prove -l

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69599f6fceb88320ad55266a361bf41f)