### PR TITLE
Release 1.79

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.79  2026-01-04
+
+    - Promote release to version 1.79 including the boolean handling
+      improvements for numeric rounding helpers and expanded coverage.
+
 1.78  2026-01-04
 
     - Promote release to version 1.78 after tightening percentile

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.78';
+our $VERSION = '1.79';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
- Version 1.78
+ Version 1.79
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Util/Transform.pm
+++ b/lib/JQ/Lite/Util/Transform.pm
@@ -62,6 +62,11 @@ sub _apply_numeric_function {
 
     return undef if !defined $value;
 
+    if (ref($value) eq 'JSON::PP::Boolean') {
+        my $numeric = $value ? 1 : 0;
+        return $callback->($numeric);
+    }
+
     if (!ref $value) {
         return looks_like_number($value) ? $callback->($value) : $value;
     }

--- a/t/ceil_floor.t
+++ b/t/ceil_floor.t
@@ -6,7 +6,8 @@ use JQ::Lite;
 my $json = q({
   "price": 19.2,
   "debt": -1.7,
-  "numbers": [1.1, -1.1, "n/a", null, [2.3, -2.3]]
+  "numbers": [1.1, -1.1, "n/a", null, [2.3, -2.3]],
+  "bools": [true, false, [true]]
 });
 
 my $jq = JQ::Lite->new;
@@ -24,6 +25,13 @@ is_deeply(
     'ceil processes arrays recursively and leaves non-numeric values untouched'
 );
 
+my @ceil_bools = $jq->run_query($json, '.bools | ceil');
+is_deeply(
+    $ceil_bools[0],
+    [1, 0, [1]],
+    'ceil treats booleans as numeric values'
+);
+
 my @floor_price = $jq->run_query($json, '.price | floor');
 is($floor_price[0], 19, 'floor rounds positive scalar down');
 
@@ -35,6 +43,13 @@ is_deeply(
     $floor_values[0],
     [1, -2, 'n/a', undef, [2, -3]],
     'floor processes arrays recursively and leaves non-numeric values untouched'
+);
+
+my @floor_bools = $jq->run_query($json, '.bools | floor');
+is_deeply(
+    $floor_bools[0],
+    [1, 0, [1]],
+    'floor treats booleans as numeric values'
 );
 
 

--- a/t/round.t
+++ b/t/round.t
@@ -8,7 +8,8 @@ my $json = q({
   "discount": 1.5,
   "debt": -1.7,
   "tiny": -0.2,
-  "numbers": [1.49, 1.5, -1.49, -1.5, "n/a", null, [2.6, -2.6, 3]]
+  "numbers": [1.49, 1.5, -1.49, -1.5, "n/a", null, [2.6, -2.6, 3]],
+  "bools": [true, false, [true]]
 });
 
 my $jq = JQ::Lite->new;
@@ -30,6 +31,13 @@ is_deeply(
     $round_values[0],
     [1, 2, -1, -2, 'n/a', undef, [3, -3, 3]],
     'round processes arrays recursively and preserves non-numeric values'
+);
+
+my @round_bools = $jq->run_query($json, '.bools | round');
+is_deeply(
+    $round_bools[0],
+    [1, 0, [1]],
+    'round treats booleans as numeric values'
 );
 
 my @round_missing = $jq->run_query($json, '.missing | round');


### PR DESCRIPTION
## Summary
- bump the distribution version to 1.79 in JQ::Lite
- document the release notes for the boolean rounding improvements

## Testing
- prove -lr t


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959c69cf7988320a91c1257ab52b135)