### PR TITLE
Bump version to 1.80

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.80  2026-01-04
+
+    - Promote release to version 1.80 reflecting normalized boolean path
+      traversal handling in getpath.
+
 1.79  2026-01-04
 
     - Promote release to version 1.79 including the boolean handling

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.79';
+our $VERSION = '1.80';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
- Version 1.79
+ Version 1.80
 
 =head1 SYNOPSIS
 

--- a/t/getpath.t
+++ b/t/getpath.t
@@ -52,6 +52,20 @@ ok($boolean_path[0], 'getpath handles JSON::PP::Boolean values');
 my @negative_index = $jq->run_query($json, '.profile | getpath(["emails", -1])');
 is($negative_index[0], 'alice.work@example.com', 'getpath supports negative indices for arrays');
 
+my $boolean_keys = encode_json({ true => 'yes', false => 'no' });
+my @bool_true  = $jq->run_query($boolean_keys, 'getpath([true])');
+my @bool_false = $jq->run_query($boolean_keys, 'getpath([false])');
+
+is($bool_true[0], 'yes', 'getpath resolves boolean true key to string key');
+is($bool_false[0], 'no', 'getpath resolves boolean false key to string key');
+
+my $boolean_indices = q([10, 20, 30]);
+my @bool_index_zero = $jq->run_query($boolean_indices, 'getpath([false])');
+my @bool_index_one  = $jq->run_query($boolean_indices, 'getpath([true])');
+
+is($bool_index_zero[0], 10, 'getpath treats boolean false as index 0');
+is($bool_index_one[0], 20, 'getpath treats boolean true as index 1');
+
 my @non_array = $jq->run_query('"scalar"', 'getpath([0])');
 ok(!defined $non_array[0], 'getpath returns undef when traversing non-container with path');
 


### PR DESCRIPTION
## Summary
- update JQ::Lite version metadata to 1.80 in code and documentation
- record the 1.80 release in the changelog highlighting the boolean path traversal fix

## Testing
- prove -l t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959e79a83808320898567be42983475)