### PR TITLE
Release 1.84

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+1.84  2026-01-05
+
+    - Promote release to version 1.84 incorporating stricter path element
+      validation and expanded coverage for setpath() and delpaths().
+
 1.83  2026-01-05
 
     - Promote release to version 1.83 capturing the compile-time validation

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '1.83';
+our $VERSION = '1.84';
 
 sub new {
     my ($class, %opts) = @_;
@@ -60,7 +60,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
- Version 1.83
+Version 1.84
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Util/Paths.pm
+++ b/lib/JQ/Lite/Util/Paths.pm
@@ -490,6 +490,13 @@ sub _validate_path_array {
 
     die "$caller(): path must be an array" if ref($path) ne 'ARRAY';
 
+    for my $segment (@$path) {
+        my $is_boolean = ref($segment) && ref($segment) eq 'JSON::PP::Boolean';
+
+        die "$caller(): path elements must be defined" if !defined $segment;
+        die "$caller(): path elements must be scalars" if ref($segment) && !$is_boolean;
+    }
+
     return [ @$path ];
 }
 

--- a/t/delpaths.t
+++ b/t/delpaths.t
@@ -74,5 +74,27 @@ like(
     'delpaths rejects paths arrays containing non-array entries'
 );
 
+$error = eval {
+    $jq->run_query(
+        $json_object,
+        '.profile | delpaths([["name", {"nested":true}]])'
+    );
+    1;
+};
+ok(!$error, 'delpaths throws when any path segment is non-scalar');
+like(
+    $@,
+    qr/^delpaths\(\): path elements must be scalars/,
+    'delpaths rejects non-scalar path segments'
+);
+
+$error = eval { $jq->run_query($json_object, '.profile | delpaths([[null]])'); 1 };
+ok(!$error, 'delpaths throws when a path contains an undefined/null segment');
+like(
+    $@,
+    qr/^delpaths\(\): path elements must be defined/,
+    'delpaths rejects null path elements'
+);
+
 done_testing;
 

--- a/t/setpath.t
+++ b/t/setpath.t
@@ -121,4 +121,12 @@ my $error = eval { $jq->run_query($json, 'setpath("details"; 1)'); 1 };
 ok(!$error, 'setpath throws on non-array path argument');
 like($@, qr/^setpath\(\): path must be an array/, 'setpath error message indicates array requirement');
 
+$error = eval { $jq->run_query($json, 'setpath(["details", null]; 1)'); 1 };
+ok(!$error, 'setpath throws when path contains undefined/null elements');
+like($@, qr/^setpath\(\): path elements must be defined/, 'setpath rejects null path elements');
+
+$error = eval { $jq->run_query($json, 'setpath(["details", {"oops":true}]; 1)'); 1 };
+ok(!$error, 'setpath throws when path contains non-scalar elements');
+like($@, qr/^setpath\(\): path elements must be scalars/, 'setpath rejects non-scalar path segments');
+
 done_testing;


### PR DESCRIPTION
## Summary
- bump JQ::Lite to version 1.84
- record release notes for stricter path validation coverage

## Testing
- prove -l

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae9d084e88320955da323a1d2e9d2)