### PR TITLE
Enforce queries for raw input mode and test usage errors

### DIFF
--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -394,13 +394,21 @@ if (@query_files) {
 
 if (@ARGV == 0) {
     if (!defined $query) {
+        if ($slurpfile_probably_missing_file) {
+            _usage_error('--slurpfile requires a file path');
+        }
+
+        if ($raw_input) {
+            my $reason = $slurp_input
+                ? '--raw-input requires a query when used with --slurp.'
+                : '--raw-input requires a query when not using --slurp.';
+            _usage_error($reason);
+        }
+
         if ($null_input) {
             $query = '.';
         } else {
             if ($non_help_option_used) {
-                if ($slurpfile_probably_missing_file) {
-                    _usage_error('--slurpfile requires a file path');
-                }
                 _usage_error('filter expression is required');
             }
 
@@ -712,8 +720,11 @@ sub print_results {
 }
 
 # ---------- Interactive mode ----------
-if ($raw_input && !$slurp_input && !defined $query) {
-    _usage_error('--raw-input requires a query when not using --slurp.');
+if ($raw_input && !defined $query) {
+    my $reason = $slurp_input
+        ? '--raw-input requires a query when used with --slurp.'
+        : '--raw-input requires a query when not using --slurp.';
+    _usage_error($reason);
 }
 
 if (!defined $query) {

--- a/t/raw_input_cli.t
+++ b/t/raw_input_cli.t
@@ -50,4 +50,28 @@ is($exit, 0, 'process exits successfully for slurped raw text');
 like($stderr, qr/No such file or directory|Cannot open file/, 'error surfaced when file is missing under --raw-input');
 ok($exit != 0, 'nonexistent file under raw input causes non-zero exit');
 
+($stdout, $stderr, $exit) = run_cli(
+    args => [ '-R' ],
+);
+
+is($stdout, '', 'no output is produced when --raw-input is provided without a query');
+like(
+    $stderr,
+    qr/^\[USAGE\]--raw-input requires a query when not using --slurp\./,
+    'usage error is raised when --raw-input lacks a query'
+);
+is($exit, 5, '--raw-input without a query exits with usage code');
+
+($stdout, $stderr, $exit) = run_cli(
+    args => [ '-R', '-s' ],
+);
+
+is($stdout, '', 'no output is produced when --raw-input and --slurp are used without a query');
+like(
+    $stderr,
+    qr/^\[USAGE\]--raw-input requires a query when used with --slurp\./,
+    'usage error is raised when --raw-input --slurp lacks a query'
+);
+is($exit, 5, '--raw-input --slurp without a query exits with usage code');
+
 done_testing;


### PR DESCRIPTION
## Summary
- enforce usage errors when running jq-lite with --raw-input (with or without --slurp) but no query
- keep raw input interactive guard in sync with CLI argument parsing
- extend raw input CLI tests to cover missing-query scenarios

## Testing
- prove -lr t

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695afade7e6083209bf19055015310f6)