### PR TITLE
Fix YAML::PP boolean backend and bump version to 2.41

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+2.41  2026-02-23
+
+  - Fix YAML::PP loader boolean backend selection by using
+    `boolean => 'JSON::PP'`, avoiding runtime warnings/errors when
+    parsing YAML input.
+  - Bump module version to 2.41.
+
 2.40  2026-02-23
 
   - Strengthen replace() test coverage for boundary conditions:

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -659,7 +659,7 @@ sub _build_yaml_loader {
     }
     elsif (eval { require YAML::PP; 1 }) {
         require YAML::PP;
-        my $yp = YAML::PP->new(boolean => 'JSON');
+        my $yp = YAML::PP->new(boolean => 'JSON::PP');
         return (sub { $yp->load_string($_[0]) }, 'YAML::PP');
     }
     else {
@@ -1146,4 +1146,3 @@ This software is released under the same terms as Perl itself.
 =head1 DISCLAIMER
 
 jq-lite is provided "as is", without warranty of any kind.
-

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '2.40';
+our $VERSION = '2.41';
 
 sub new {
     my ($class, %opts) = @_;
@@ -78,7 +78,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
-Version 2.40
+Version 2.41
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
### Motivation

- Avoid runtime warnings/errors when parsing YAML with `YAML::PP` caused by an unsupported boolean backend name.  
- Record the fix in the release notes and publish the new module version.

### Description

- Change `YAML::PP` initialization in `bin/jq-lite` from `boolean => 'JSON'` to `boolean => 'JSON::PP'` so the loader uses a supported boolean backend.  
- Bump the module version from `2.40` to `2.41` in `lib/JQ/Lite.pm` and update the POD `Version` text to `2.41`.  
- Add a `2.41` entry to `Changes` documenting the YAML::PP boolean backend fix and the version bump.

### Testing

- Ran `perl -c bin/jq-lite` and it reported `syntax OK`.  
- Ran `perl bin/jq-lite -v` which printed `jq-lite 2.41`.  
- Ran a YAML decode smoke check with `perl bin/jq-lite --yaml '.users | length'` against a small sample YAML and it returned `2`.  
- Ran `prove -lv t/yaml_cli.t` in this environment and the YAML tests were skipped due to the runtime Perl version constraint (Perl < 5.40), resulting in `NOTESTS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c30eb8ebc8320b64a3a8cde3249e3)