### PR TITLE
Refactor array index normalization in path helpers and bump version to 2.44

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+2.44  2026-04-25
+
+  - Refactor path traversal helpers to share array index normalization logic.
+  - Bump module version to 2.44.
+
 2.43  2026-03-23
 
   - Stabilize compact/ascii CLI regression tests by asserting

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '2.43';
+our $VERSION = '2.44';
 
 sub new {
     my ($class, %opts) = @_;
@@ -78,7 +78,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
-Version 2.43
+Version 2.44
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Util/Paths.pm
+++ b/lib/JQ/Lite/Util/Paths.pm
@@ -77,11 +77,7 @@ sub _get_path_value {
         if ($segment->{type} eq 'index') {
             return undef unless ref $cursor eq 'ARRAY';
 
-            my $idx = $segment->{value};
-            my $numeric = int($idx);
-            if ($idx =~ /^-?\d+$/) {
-                $numeric += @$cursor if $numeric < 0;
-            }
+            my $numeric = _normalize_path_array_index($segment->{value}, scalar @$cursor);
 
             return undef if $numeric < 0 || $numeric > $#$cursor;
 
@@ -175,11 +171,7 @@ sub _set_path_value {
         if ($segment->{type} eq 'index') {
             return unless ref $cursor eq 'ARRAY';
 
-            my $idx = $segment->{value};
-            my $numeric = int($idx);
-            if ($idx =~ /^-?\d+$/) {
-                $numeric += @$cursor if $numeric < 0;
-            }
+            my $numeric = _normalize_path_array_index($segment->{value}, scalar @$cursor);
 
             return if $numeric < 0;
 
@@ -199,6 +191,17 @@ sub _set_path_value {
     }
 
     return;
+}
+
+sub _normalize_path_array_index {
+    my ($idx, $array_size) = @_;
+
+    my $numeric = int($idx);
+    if ($idx =~ /^-?\d+$/) {
+        $numeric += $array_size if $numeric < 0;
+    }
+
+    return $numeric;
 }
 
 sub _parse_path_segments {


### PR DESCRIPTION
### Motivation

- Consolidate duplicated logic for normalizing array indices (including negative indices) used by path traversal helpers to reduce code duplication and ensure consistent behavior.
- Release a new patch version reflecting the refactor and related changes.

### Description

- Added `_normalize_path_array_index` in `lib/JQ/Lite/Util/Paths.pm` and replaced duplicated index normalization code in `_get_path_value` and `_set_path_value` to call the new helper.
- Bumped module version from `2.43` to `2.44` in `lib/JQ/Lite.pm` and updated the `Changes` file with the new release entry and changelog notes.
- Kept existing parsing behavior in `_parse_path_segments` and preserved surrounding path handling logic.

### Testing

- Ran the test suite with `prove -l t` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec066a3fb48320a1558ee98728c996)