### PR TITLE
Include docs, utility modules, and tests in MANIFEST; remove generated META files; bump version to 2.45

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+2.45  2026-05-06
+
+  - Fix MANIFEST to include missing docs, installer, utility modules,
+    and test files in source distributions.
+  - Remove generated META.json and META.yml entries from MANIFEST so
+    manifest checks pass from a clean checkout.
+  - Bump module version to 2.45.
+
 2.44  2026-04-25
 
   - Refactor path traversal helpers to share array index normalization logic.

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,11 +1,18 @@
 bin/jq-lite
 Changes
 CONTRIBUTING.md
+docs/DESIGN.md
+docs/FUNCTIONS.md
+docs/cli-contract.md
+install-jq-lite.ps1
 lib/JQ/Lite.pm
 lib/JQ/Lite/Expression.pm
 lib/JQ/Lite/Filters.pm
 lib/JQ/Lite/Parser.pm
 lib/JQ/Lite/Util.pm
+lib/JQ/Lite/Util/Parsing.pm
+lib/JQ/Lite/Util/Paths.pm
+lib/JQ/Lite/Util/Transform.pm
 LICENSE
 Makefile.PL
 MANIFEST			This list of files
@@ -32,12 +39,14 @@ t/case_transform.t
 t/ceil_floor.t
 t/chunks.t
 t/clamp.t
+t/cli_contract.t
 t/coalesce.t
 t/comma.t
 t/compact.t
 t/compact_output_cli.t
 t/contains.t
 t/contains_function.t
+t/contains_subset_function.t
 t/count.t
 t/csv_format.t
 t/decode_utf8_input.t
@@ -66,8 +75,11 @@ t/has_function.t
 t/if_then_else.t
 t/index.t
 t/indices.t
+t/inside.t
 t/is_empty.t
 t/join.t
+t/json_formatter.t
+t/keys.t
 t/keys_unsorted.t
 t/leaf_paths.t
 t/length.t
@@ -85,6 +97,7 @@ t/not.t
 t/nth.t
 t/null_input_cli.t
 t/object_constructor.t
+t/object_iteration.t
 t/objects.t
 t/path.t
 t/paths.t
@@ -92,7 +105,10 @@ t/percentile.t
 t/pick.t
 t/pipe_select_name.t
 t/pluck.t
+t/quoted_field_access.t
 t/range.t
+t/raw_input_cli.t
+t/rawfile_cli.t
 t/recurse.t
 t/reduce.t
 t/rest.t
@@ -105,6 +121,8 @@ t/select_stream.t
 t/setpath.t
 t/slice.t
 t/slurp_cli.t
+t/slurpfile_cli.t
+t/smoke_cli.t
 t/sort_by.t
 t/sort_desc.t
 t/sort_unique.t
@@ -120,6 +138,7 @@ t/tostring.t
 t/transpose.t
 t/trim.t
 t/trimstr.t
+t/try_catch.t
 t/tsv_format.t
 t/uri_format.t
 t/type.t
@@ -127,5 +146,3 @@ t/unique_by.t
 t/values.t
 t/walk.t
 t/yaml_cli.t
-META.yml                                 Module YAML meta-data (added by MakeMaker)
-META.json                                Module JSON meta-data (added by MakeMaker)

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '2.44';
+our $VERSION = '2.45';
 
 sub new {
     my ($class, %opts) = @_;
@@ -78,7 +78,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
-Version 2.44
+Version 2.45
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
### Motivation
- Ensure source distributions contain missing documentation, the installer, utility modules, and newly added test files so packaging and downstream installs are complete.
- Make manifest checks reproducible from a clean checkout by not listing generated metadata files in `MANIFEST`.
- Prepare and record a new release by bumping the module version to `2.45` and adding release notes.

### Description
- Update `MANIFEST` to add `docs/*`, `install-jq-lite.ps1`, `lib/JQ/Lite/Util/*.pm`, and numerous `t/*.t` test files to the list of files included in source distributions.
- Remove `META.yml` and `META.json` entries from `MANIFEST` so generated metadata files are not expected to exist in a clean checkout.
- Update `Changes` to document the 2.45 release and bump the version constant in `lib/JQ/Lite.pm` to `2.45`.

### Testing
- Ran the test suite with `prove -l t` and the tests completed successfully.
- Performed basic syntax checks with `perl -c` on modified modules and found no compile-time errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2d7ebe508320975f787cbccd5593)