### PR TITLE
[codex] Enable strict mode in avg_by test

### DIFF
--- a/t/avg_by.t
+++ b/t/avg_by.t
@@ -1,3 +1,4 @@
+use strict;
 use warnings;
 use Test::More;
 use JQ::Lite;


### PR DESCRIPTION
## Summary

- Add `use strict;` to `t/avg_by.t` so the avg_by test matches the strictness used by the rest of the test suite.

## Impact

This does not add a feature or change runtime behavior. It improves test hygiene by catching accidental symbolic references or undeclared variables in this test file.

## Validation

- `perl -Ilib t/avg_by.t`
- `make test`