### PR TITLE
Centralize CLI error handling and bump version to 2.47

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+2.47  2026-05-29
+
+  - Centralize CLI error exit handling to reduce duplicated code.
+  - Bump module version to 2.47.
+
 2.46  2026-05-10
 
   - Avoid string eval when evaluating select() arithmetic comparisons.

--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -31,36 +31,32 @@ my %arg_vars;
 my @slurpfiles;
 my $slurpfile_probably_missing_file = 0;
 
+sub _exit_with_error {
+    my ($tag, $default_message, $exit_code, $message) = @_;
+    $message = defined($message) && $message ne '' ? $message : $default_message;
+    $message =~ s/\s+\z//;
+    warn "[$tag]$message\n";
+    exit $exit_code;
+}
+
 sub _usage_error {
     my ($message) = @_;
-    $message ||= 'invalid usage';
-    $message =~ s/\s+\z//;
-    warn "[USAGE]$message\n";
-    exit 5;
+    _exit_with_error('USAGE', 'invalid usage', 5, $message);
 }
 
 sub _input_error {
     my ($message) = @_;
-    $message ||= 'input error';
-    $message =~ s/\s+\z//;
-    warn "[INPUT]$message\n";
-    exit 4;
+    _exit_with_error('INPUT', 'input error', 4, $message);
 }
 
 sub _compile_error {
     my ($message) = @_;
-    $message ||= 'compile error';
-    $message =~ s/\s+\z//;
-    warn "[COMPILE]$message\n";
-    exit 2;
+    _exit_with_error('COMPILE', 'compile error', 2, $message);
 }
 
 sub _runtime_error {
     my ($message) = @_;
-    $message ||= 'runtime error';
-    $message =~ s/\s+\z//;
-    warn "[RUNTIME]$message\n";
-    exit 3;
+    _exit_with_error('RUNTIME', 'runtime error', 3, $message);
 }
 
 sub _validate_query_syntax {

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '2.46';
+our $VERSION = '2.47';
 
 sub new {
     my ($class, %opts) = @_;
@@ -78,7 +78,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
-Version 2.46
+Version 2.47
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
### Motivation

- Reduce duplicated code in the CLI by centralizing error message formatting and exit behavior.
- Bump the module version for the new release and record the change in the `Changes` file.

### Description

- Add `_exit_with_error` helper to `bin/jq-lite` and refactor `_usage_error`, `_input_error`, `_compile_error`, and `_runtime_error` to call it.
- Update `lib/JQ/Lite.pm` `our $VERSION` and the POD `Version` string to `2.47`.
- Add `2.47` entry to `Changes` documenting the centralization and version bump.

### Testing

- Ran the module test suite via `prove -l t` and the tests completed successfully.
- Performed a CLI smoke test by running `bin/jq-lite --help` which produced the expected usage output and exit behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eaad69cd0832088af976b0f9e4d20)