### PR TITLE
Refactor CLI bracket syntax validation

### DIFF
--- a/bin/jq-lite
+++ b/bin/jq-lite
@@ -59,6 +59,12 @@ sub _runtime_error {
     _exit_with_error('RUNTIME', 'runtime error', 3, $message);
 }
 
+my %BRACKET_PAIRS = (
+    ')' => '(',
+    ']' => '[',
+    '}' => '{',
+);
+
 sub _validate_query_syntax {
     my ($query) = @_;
 
@@ -98,12 +104,7 @@ sub _validate_query_syntax {
 
         if ($char eq ')' || $char eq ']' || $char eq '}') {
             my $open = pop @stack;
-            my %pairs = (
-                ')' => '(',
-                ']' => '[',
-                '}' => '{',
-            );
-            if (!defined $open || $open ne $pairs{$char}) {
+            if (!defined $open || $open ne $BRACKET_PAIRS{$char}) {
                 _compile_error('Invalid query syntax: unmatched brackets');
             }
         }


### PR DESCRIPTION
### Motivation
- Avoid constructing the bracket-pair lookup hash on every character during CLI query syntax validation by hoisting it out of the per-character loop to a single static table, while preserving existing behavior.

### Description
- Move the bracket-pair mapping into a module-level `%BRACKET_PAIRS` and replace the per-iteration `%pairs` construction with a lookup against `
%BRACKET_PAIRS` in `bin/jq-lite`, keeping the validation logic unchanged.

### Testing
- Ran `perl -c bin/jq-lite` and `prove -lr t/cli_contract.t t/smoke_cli.t` and the full test suite with `prove -lr t`, all of which completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b8574e4508320a52734f6bc43944f)