### PR TITLE
Fix comparisons after pipeline filters; preserve dotted field names; improve length handling

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,10 @@
+2.48  2026-07-19
+
+  - Fix comparisons after pipeline filters, including bare length and
+    parenthesized pipeline expressions.
+  - Prevent dotted field names such as .count from colliding with built-ins.
+  - Bump module version to 2.48.
+
 2.47  2026-05-29
 
   - Centralize CLI error exit handling to reduce duplicated code.

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '2.47';
+our $VERSION = '2.48';
 
 sub new {
     my ($class, %opts) = @_;
@@ -53,13 +53,27 @@ sub _run_query_internal {
     for my $part (@parts) {
         my @next_results;
 
+        # Resolve plain dotted paths before filter dispatch.  Retaining the
+        # leading dot in the parser prevents fields such as `.count` from
+        # colliding with built-in filter names.
+        if ($part =~ /^\.[A-Za-z_][A-Za-z0-9_?]*(?:\.[A-Za-z_][A-Za-z0-9_?]*)*$/) {
+            my $path = substr($part, 1);
+            for my $item (@results) {
+                push @next_results, JQ::Lite::Util::_traverse($item, $path);
+            }
+            @results = @next_results;
+            next;
+        }
+
         if (JQ::Lite::Filters::apply($self, $part, \@results, \@next_results)) {
             @results = @next_results;
             next;
         }
 
         for my $item (@results) {
-            push @next_results, JQ::Lite::Util::_traverse($item, $part);
+            my $path = $part;
+            $path =~ s/^\.// unless $path =~ /^\.\s*\[/;
+            push @next_results, JQ::Lite::Util::_traverse($item, $path);
         }
         @results = @next_results;
     }
@@ -78,7 +92,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
-Version 2.47
+Version 2.48
 
 =head1 SYNOPSIS
 

--- a/lib/JQ/Lite/Expression.pm
+++ b/lib/JQ/Lite/Expression.pm
@@ -71,7 +71,14 @@ sub _tokenize {
             next;
         }
 
-        if ($char =~ /[+\-*\/%]/) {
+        my $comparison = substr($expr, $i, 2);
+        if ($comparison =~ /^(?:==|!=|>=|<=)$/) {
+            push @tokens, { type => 'OP', value => $comparison };
+            $i += 2;
+            next;
+        }
+
+        if ($char =~ /[+\-*\/%<>]/) {
             push @tokens, { type => 'OP', value => $char };
             $i++;
             next;
@@ -246,6 +253,12 @@ sub _consume_single_string {
 }
 
 my %LBP = (
+    '==' => 5,
+    '!=' => 5,
+    '>=' => 5,
+    '<=' => 5,
+    '>'  => 5,
+    '<'  => 5,
     '+' => 10,
     '-' => 10,
     '*' => 20,
@@ -330,6 +343,13 @@ sub _nud {
         if ($token->{value} eq 'null') {
             return { type => 'NULL', value => undef };
         }
+        if ($token->{value} eq 'length') {
+            return {
+                type => 'CALL',
+                name => 'length',
+                args => [ { type => 'CURRENT' } ],
+            };
+        }
         return { type => 'IDENT', name => $token->{value} };
     }
 
@@ -404,6 +424,22 @@ sub _eval_node {
         my $left_value  = _eval_node($node->{left},  $opts);
         my $right_value = _eval_node($node->{right}, $opts);
 
+        if ($node->{op} eq '==' || $node->{op} eq '!=') {
+            my $equal = _values_equal($left_value, $right_value);
+            $equal = !$equal if $node->{op} eq '!=';
+            return $equal ? JSON::PP::true : JSON::PP::false;
+        }
+
+        if ($node->{op} =~ /^(?:>=|<=|>|<)$/) {
+            my $left_num  = $opts->{coerce_number}->($left_value,  'left operand');
+            my $right_num = $opts->{coerce_number}->($right_value, 'right operand');
+            my $result = $node->{op} eq '>=' ? $left_num >= $right_num
+                       : $node->{op} eq '<=' ? $left_num <= $right_num
+                       : $node->{op} eq '>'  ? $left_num >  $right_num
+                       :                       $left_num <  $right_num;
+            return $result ? JSON::PP::true : JSON::PP::false;
+        }
+
         my $left_num  = $opts->{coerce_number}->($left_value,  'left operand');
         my $right_num = $opts->{coerce_number}->($right_value, 'right operand');
 
@@ -435,6 +471,40 @@ sub _eval_node {
     }
 
     _parse_error();
+}
+
+sub _values_equal {
+    my ($left, $right) = @_;
+
+    return 1 if !defined $left && !defined $right;
+    return 0 if !defined $left || !defined $right;
+    return JSON::PP::is_bool($left) && JSON::PP::is_bool($right)
+        ? (!!$left == !!$right) : 0
+        if JSON::PP::is_bool($left) || JSON::PP::is_bool($right);
+
+    if (!ref $left && !ref $right) {
+        return looks_like_number($left) && looks_like_number($right)
+            ? $left == $right : "$left" eq "$right";
+    }
+
+    if (ref $left eq 'ARRAY' && ref $right eq 'ARRAY') {
+        return 0 unless @$left == @$right;
+        for my $i (0 .. $#$left) {
+            return 0 unless _values_equal($left->[$i], $right->[$i]);
+        }
+        return 1;
+    }
+
+    if (ref $left eq 'HASH' && ref $right eq 'HASH') {
+        return 0 unless keys(%$left) == keys(%$right);
+        for my $key (keys %$left) {
+            return 0 unless exists $right->{$key}
+                && _values_equal($left->{$key}, $right->{$key});
+        }
+        return 1;
+    }
+
+    return 0;
 }
 
 sub _default_coerce_number {

--- a/lib/JQ/Lite/Expression.pm
+++ b/lib/JQ/Lite/Expression.pm
@@ -5,6 +5,7 @@ use warnings;
 
 use JSON::PP ();    # lightweight decoder for string literals
 use Scalar::Util qw(looks_like_number);
+use B qw(SVp_IOK SVp_NOK SVp_POK);
 
 # Internal constant used to signal that parsing failed and callers should
 # silently fall back to other heuristics.
@@ -425,18 +426,17 @@ sub _eval_node {
         my $right_value = _eval_node($node->{right}, $opts);
 
         if ($node->{op} eq '==' || $node->{op} eq '!=') {
-            my $equal = _values_equal($left_value, $right_value);
+            my $equal = _compare_values($left_value, $right_value) == 0;
             $equal = !$equal if $node->{op} eq '!=';
             return $equal ? JSON::PP::true : JSON::PP::false;
         }
 
         if ($node->{op} =~ /^(?:>=|<=|>|<)$/) {
-            my $left_num  = $opts->{coerce_number}->($left_value,  'left operand');
-            my $right_num = $opts->{coerce_number}->($right_value, 'right operand');
-            my $result = $node->{op} eq '>=' ? $left_num >= $right_num
-                       : $node->{op} eq '<=' ? $left_num <= $right_num
-                       : $node->{op} eq '>'  ? $left_num >  $right_num
-                       :                       $left_num <  $right_num;
+            my $comparison = _compare_values($left_value, $right_value);
+            my $result = $node->{op} eq '>=' ? $comparison >= 0
+                       : $node->{op} eq '<=' ? $comparison <= 0
+                       : $node->{op} eq '>'  ? $comparison >  0
+                       :                       $comparison <  0;
             return $result ? JSON::PP::true : JSON::PP::false;
         }
 
@@ -473,38 +473,68 @@ sub _eval_node {
     _parse_error();
 }
 
-sub _values_equal {
+sub compare_values {
+    my ($left, $right, $operator) = @_;
+    my $comparison = _compare_values($left, $right);
+    my $result = $operator eq '==' ? $comparison == 0
+               : $operator eq '!=' ? $comparison != 0
+               : $operator eq '>=' ? $comparison >= 0
+               : $operator eq '<=' ? $comparison <= 0
+               : $operator eq '>'  ? $comparison >  0
+               : $operator eq '<'  ? $comparison <  0
+               : 0;
+    return $result ? JSON::PP::true : JSON::PP::false;
+}
+
+sub _compare_values {
     my ($left, $right) = @_;
 
-    return 1 if !defined $left && !defined $right;
-    return 0 if !defined $left || !defined $right;
-    return JSON::PP::is_bool($left) && JSON::PP::is_bool($right)
-        ? (!!$left == !!$right) : 0
-        if JSON::PP::is_bool($left) || JSON::PP::is_bool($right);
+    my $left_type  = _value_type($left);
+    my $right_type = _value_type($right);
+    return $left_type <=> $right_type if $left_type != $right_type;
 
-    if (!ref $left && !ref $right) {
-        return looks_like_number($left) && looks_like_number($right)
-            ? $left == $right : "$left" eq "$right";
+    return 0 if $left_type == 0;
+    return (!!$left) <=> (!!$right) if $left_type == 1;
+    return $left <=> $right if $left_type == 2;
+    return "$left" cmp "$right" if $left_type == 3;
+
+    if ($left_type == 4) {
+        my $limit = @$left < @$right ? @$left : @$right;
+        if ($limit) {
+            for my $i (0 .. $limit - 1) {
+                my $comparison = _compare_values($left->[$i], $right->[$i]);
+                return $comparison if $comparison;
+            }
+        }
+        return @$left <=> @$right;
     }
 
-    if (ref $left eq 'ARRAY' && ref $right eq 'ARRAY') {
-        return 0 unless @$left == @$right;
-        for my $i (0 .. $#$left) {
-            return 0 unless _values_equal($left->[$i], $right->[$i]);
+    if ($left_type == 5) {
+        my @left_keys  = sort keys %$left;
+        my @right_keys = sort keys %$right;
+        my $keys_comparison = _compare_values(\@left_keys, \@right_keys);
+        return $keys_comparison if $keys_comparison;
+        for my $key (@left_keys) {
+            my $comparison = _compare_values($left->{$key}, $right->{$key});
+            return $comparison if $comparison;
         }
-        return 1;
-    }
-
-    if (ref $left eq 'HASH' && ref $right eq 'HASH') {
-        return 0 unless keys(%$left) == keys(%$right);
-        for my $key (keys %$left) {
-            return 0 unless exists $right->{$key}
-                && _values_equal($left->{$key}, $right->{$key});
-        }
-        return 1;
+        return 0;
     }
 
     return 0;
+}
+
+sub _value_type {
+    my ($value) = @_;
+    return 0 unless defined $value;                    # null
+    return 1 if JSON::PP::is_bool($value);             # false, true
+    return 4 if ref $value eq 'ARRAY';
+    return 5 if ref $value eq 'HASH';
+    return 6 if ref $value;
+
+    my $flags = B::svref_2object(\$value)->FLAGS;
+    return 2 if ($flags & (SVp_IOK | SVp_NOK)) && !($flags & SVp_POK);
+    return 3;
 }
 
 sub _default_coerce_number {
@@ -525,4 +555,3 @@ sub _default_coerce_number {
 }
 
 1;
-

--- a/lib/JQ/Lite/Filters.pm
+++ b/lib/JQ/Lite/Filters.pm
@@ -7,6 +7,7 @@ use List::Util qw(sum min max);
 use Scalar::Util qw(looks_like_number);
 use B qw(SVp_IOK SVp_NOK);
 use JQ::Lite::Util ();
+use JQ::Lite::Expression ();
 
 sub apply {
     my ($self, $part, $results_ref, $out_ref) = @_;
@@ -93,10 +94,15 @@ sub apply {
                 );
 
                 for my $lhs_value (@lhs_values) {
-                    my ($values, $ok) = JQ::Lite::Util::_evaluate_value_expression(
-                        $self, $lhs_value, ". $operator $rhs"
+                    my ($rhs_values, $rhs_ok) = JQ::Lite::Util::_evaluate_value_expression(
+                        $self, $item, $rhs
                     );
-                    push @next_results, @$values if $ok;
+                    next unless $rhs_ok;
+                    for my $rhs_value (@$rhs_values) {
+                        push @next_results, JQ::Lite::Expression::compare_values(
+                            $lhs_value, $rhs_value, $operator
+                        );
+                    }
                 }
             }
 

--- a/lib/JQ/Lite/Filters.pm
+++ b/lib/JQ/Lite/Filters.pm
@@ -80,6 +80,30 @@ sub apply {
             return 1;
         }
 
+        # A parenthesized pipeline can be the left operand of a comparison,
+        # e.g. `(.devices | length) > 0`.  Evaluate that pipeline first, then
+        # compare each value as the current input.
+        if ($normalized =~ /^\((.*)\)\s*(==|!=|>=|<=|>|<)\s*(.+)$/s) {
+            my ($lhs, $operator, $rhs) = ($1, $2, $3);
+            @next_results = ();
+
+            for my $item (@results) {
+                my @lhs_values = $self->run_query(
+                    JQ::Lite::Util::_encode_json($item), $lhs
+                );
+
+                for my $lhs_value (@lhs_values) {
+                    my ($values, $ok) = JQ::Lite::Util::_evaluate_value_expression(
+                        $self, $lhs_value, ". $operator $rhs"
+                    );
+                    push @next_results, @$values if $ok;
+                }
+            }
+
+            @$out_ref = @next_results;
+            return 1;
+        }
+
         if ($normalized =~ /^try\b/) {
             my $body = $normalized;
             $body =~ s/^try\s*//;

--- a/lib/JQ/Lite/Parser.pm
+++ b/lib/JQ/Lite/Parser.pm
@@ -39,13 +39,17 @@ sub parse_query {
                 $_;
             }
             else {
+                # Keep the dot on plain field paths so names that match
+                # built-in filters (for example `.count`) stay unambiguous.
+                # Other legacy forms (such as `. as $x`) still use the
+                # normalized representation expected by filter dispatch.
                 my $trimmed = $rest;
                 $trimmed =~ s/^\s+|\s+$//g;
                 if ($trimmed =~ /^"(?:[^"\\]|\\.)*"$/s) {
                     my $decoded = eval { JQ::Lite::Util::_decode_json($trimmed) };
                     return $decoded if defined $decoded && !$@;
                 }
-                $rest;
+                $rest =~ /^[A-Za-z_][A-Za-z0-9_.?]*$/ ? $_ : $rest;
             }
         }
         else {

--- a/lib/JQ/Lite/Util/Parsing.pm
+++ b/lib/JQ/Lite/Util/Parsing.pm
@@ -822,6 +822,14 @@ sub _evaluate_value_expression {
 
     if (_looks_like_expression($copy)) {
         my %builtins = (
+            length => sub {
+                my ($value) = @_;
+                return 0 unless defined $value;
+                return scalar @$value if ref $value eq 'ARRAY';
+                return scalar keys %$value if ref $value eq 'HASH';
+                return length "$value" if !ref $value || JSON::PP::is_bool($value);
+                return 0;
+            },
             floor => sub {
                 my ($value) = @_;
                 my $numeric = _coerce_number_strict($value, 'floor() argument');

--- a/t/length.t
+++ b/t/length.t
@@ -26,4 +26,23 @@ is($num[0], 5, 'numeric length counts digits');
 is($bool[0], 1, 'boolean length is treated as scalar');
 is($null[0], 0, 'null length is zero');
 
+my $comparison_json = q({"devices":[{"mac":"aa"}],"count":3,"s":"x"});
+my @length_gt = $jq->run_query($comparison_json, '.devices | length > 0');
+my @length_ge = $jq->run_query($comparison_json, '.devices | length >= 1');
+my @length_eq = $jq->run_query($comparison_json, '.devices | length == 1');
+my @length_ne = $jq->run_query($comparison_json, '.devices | length != 0');
+my @count_gt  = $jq->run_query($comparison_json, '.count | . > 0');
+my @count_eq  = $jq->run_query($comparison_json, '.count | . == 3');
+my @string_eq = $jq->run_query($comparison_json, '.s | . == "x"');
+my @parenthesized = $jq->run_query($comparison_json, '(.devices | length) > 0');
+
+ok($length_gt[0], 'bare length result supports greater-than comparison');
+ok($length_ge[0], 'bare length result supports greater-than-or-equal comparison');
+ok($length_eq[0], 'bare length result supports equality comparison');
+ok($length_ne[0], 'bare length result supports inequality comparison');
+ok($count_gt[0], 'current numeric value supports comparison after a pipe');
+ok($count_eq[0], 'current numeric value supports equality after a pipe');
+ok($string_eq[0], 'current string value supports equality after a pipe');
+ok($parenthesized[0], 'parenthesized pipeline result supports comparison');
+
 done_testing;

--- a/t/length.t
+++ b/t/length.t
@@ -45,4 +45,16 @@ ok($count_eq[0], 'current numeric value supports equality after a pipe');
 ok($string_eq[0], 'current string value supports equality after a pipe');
 ok($parenthesized[0], 'parenthesized pipeline result supports comparison');
 
+my @string_number = $jq->run_query('"1"', '. == 1');
+my @string_order = $jq->run_query('{"x":"m"}', '.x < "z"');
+my @type_order = $jq->run_query('null', '. < false');
+my @nested_types = $jq->run_query('["1"]', '. == [1]');
+my @rhs_context = $jq->run_query('{"a":[1],"b":1}', '(.a | length) == .b');
+
+ok(!$string_number[0], 'numeric strings are not equal to JSON numbers');
+ok($string_order[0], 'relational comparison supports JSON strings');
+ok($type_order[0], 'relational comparison follows jq JSON type ordering');
+ok(!$nested_types[0], 'deep equality preserves nested JSON scalar types');
+ok($rhs_context[0], 'parenthesized comparison RHS uses the original input');
+
 done_testing;


### PR DESCRIPTION
### Motivation

- Ensure comparisons work when the left operand is the result of a pipeline filter, including bare `length` uses and parenthesized pipeline expressions.  
- Prevent plain dotted field names (for example `.count`) from being interpreted as built-in filter names.  
- Improve expression evaluation to support full comparison operators and robust equality semantics across JSON types.

### Description

- Bump module version to `2.48` and update module `VERSION` and release `Changes`.  
- Resolve plain dotted paths early in `JQ::Lite::_run_query_internal` so leading-dot field names are preserved and do not collide with built-in filters.  
- Adjust `Parser::parse_query` to keep the leading dot for plain field paths and avoid normalizing names that match built-ins.  
- Extend expression parsing and evaluation in `Expression.pm` to tokenize `==`, `!=`, `>=`, `<=`, `>` and `<`, add precedence, implement comparison evaluation, and add `_values_equal` to compare arrays/hashes/primitives per JSON semantics.  
- Add implicit `length` handling so bare `length` in expressions resolves to a call of the `length` builtin, and register a `length` builtin in `Util/Parsing.pm` that returns sensible results for arrays, objects, strings, numbers, booleans, and null.  
- Implement parenthesized-pipeline comparison handling in `Filters.pm` so constructs like `(.devices | length) > 0` evaluate correctly.  
- Adjust path traversal logic to strip leading dot except when the part is an array index expression, preserving expected bracketed access behavior.  
- Add `t/length.t` tests covering `length` semantics, comparisons after pipes, equality/inequality, and parenthesized pipeline comparisons.

### Testing

- Ran the test suite with `prove -l t`, including the new `t/length.t`, and all tests passed.  
- Existing automated tests were re-run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ccd4618448320b2d4672060333f76)