### PR TITLE
Prepare JQ::Lite 2.50 release

### DIFF
--- a/docs/library-integration.md
+++ b/docs/library-integration.md
@@ -72,17 +72,17 @@ For a distribution using `ExtUtils::MakeMaker`:
 WriteMakefile(
     NAME => 'My::Module',
     PREREQ_PM => {
-        'JQ::Lite' => '2.49',
+        'JQ::Lite' => '2.50',
     },
 );
 ```
 
-Choose the minimum JQ::Lite version that provides the behavior your distribution actually requires rather than automatically pinning to the newest release.
+Choose the minimum JQ::Lite version that provides the behavior your distribution actually requires rather than automatically pinning to the newest release. The structured Library API error classes documented below are available from version 2.50.
 
 For `cpanfile`:
 
 ```perl
-requires 'JQ::Lite', '>= 2.49';
+requires 'JQ::Lite', '>= 2.50';
 ```
 
 ## Error handling

--- a/lib/JQ/Lite.pm
+++ b/lib/JQ/Lite.pm
@@ -9,7 +9,7 @@ use JQ::Lite::Filters;
 use JQ::Lite::Parser;
 use JQ::Lite::Util ();
 
-our $VERSION = '2.49';
+our $VERSION = '2.50';
 
 sub new {
     my ($class, %opts) = @_;
@@ -78,7 +78,7 @@ JQ::Lite - jq-compatible JSON query engine in pure Perl (no external binaries)
 
 =head1 VERSION
 
-Version 2.49
+Version 2.50
 
 =head1 SYNOPSIS
 
@@ -668,8 +668,8 @@ the supplied suffix. Non-string values yield C<false>.
 
 Example:
 
-  .title | endswith("World")     # => true
-  .tags  | endswith("n")         # => [false, true, false]
+  .title | endswith("World")   # => true
+  .tags  | endswith("n")       # => [false, true, false]
 
 =item * substr(start[, length])
 
@@ -819,8 +819,8 @@ Example:
 
 =item * floor()
 
-Rounds numbers down to the nearest integer. Scalars and array elements that
-look like numbers are rounded downward, leaving non-numeric values untouched.
+Rounds numbers down to the nearest integer. Scalars and array elements that look
+like numbers are rounded downward, leaving non-numeric values untouched.
 
 Example:
 


### PR DESCRIPTION
## Summary

- bump `JQ::Lite` from 2.49 to 2.50 in the module version and POD
- update downstream dependency examples to require 2.50 when using the structured Library API errors introduced in this release
- keep `Makefile.PL` unchanged because it already derives the distribution version from `lib/JQ/Lite.pm`
- keep the CLI unchanged because `jq-lite -v` already prints `$JQ::Lite::VERSION`

## Release contents

This release includes the Library API stability contract, public/internal module boundary documentation, downstream integration guidance, and structured Library API error classes with regression tests.

## Validation

- `Makefile.PL` uses `VERSION_FROM => 'lib/JQ/Lite.pm'`
- `bin/jq-lite` reports `$JQ::Lite::VERSION`
- branch diff is limited to release-version/documentation changes

## Note about Changes

The existing `Changes` file contains mixed line endings. The available GitHub contents API only supports whole-file replacement, which would turn a small changelog edit into a very large unrelated line-ending diff. It is intentionally left untouched in this draft rather than rewriting historical content. A 2.50 changelog entry should be added before the release if it can be done with a line-preserving local git edit.
