### PR TITLE
Update actions/checkout to v7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Perl
         uses: shogo82148/actions-setup-perl@v1


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v4 to v7
- use the Node.js 24-based checkout action and remove the Node.js 20 deprecation warning

## Test

- GitHub Actions Perl test matrix